### PR TITLE
Fix reading very large metadata documents

### DIFF
--- a/Simple.OData.Client.V3.Adapter/ODataAdapter.cs
+++ b/Simple.OData.Client.V3.Adapter/ODataAdapter.cs
@@ -41,7 +41,7 @@ namespace Simple.OData.Client.V3.Adapter
         {
             var readerSettings = new ODataMessageReaderSettings();
             readerSettings.MessageQuotas.MaxReceivedMessageSize = Int32.MaxValue;
-            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response)))
+            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response), readerSettings))
             {
                 Model = messageReader.ReadMetadataDocument();
             }


### PR DESCRIPTION
Ran into the 1MB limit on 1C:Enterprise OData Service
