### PR TITLE
Add ability to set ReadUntypedAsString to false

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -229,6 +229,14 @@ namespace Simple.OData.Client
         public ODataTrace TraceFilter { get; set; }
 
         /// <summary>
+        /// Gets or sets the value that indicates either to read untyped properties as strings.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> (Default) to read untyped values as strings; <c>false</c> otherwise.
+        /// </value>
+        public bool ReadUntypedAsString { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ODataClientSettings"/> class.
         /// </summary>
         public ODataClientSettings()
@@ -303,6 +311,7 @@ namespace Simple.OData.Client
             this.AfterResponseAsync = session.Settings.AfterResponseAsync;
             this.OnTrace = session.Settings.OnTrace;
             this.TraceFilter = session.Settings.TraceFilter;
+            this.ReadUntypedAsString = session.Settings.ReadUntypedAsString;
         }
     }
 }

--- a/src/Simple.OData.Client.UnitTests/Core/OpenTypesTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/OpenTypesTests.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Moq;
+using Simple.OData.Client.V4.Adapter;
+using Xunit;
+
+namespace Simple.OData.Client.Tests.Core
+{
+    public class OpenTypesTests : CoreTestBase
+    {
+        public override string MetadataFile => "OpenTypes.xml";
+        public override IFormatSettings FormatSettings => new ODataV4Format();
+
+        [Fact]
+        public async Task ReadUntypedAsStrings()
+        {
+            _session.Settings.ReadUntypedAsString = false;
+            var response = SetUpResourceMock("OpenTypeV401.json");
+            var edmModel = await _client.GetMetadataAsync<IEdmModel>();
+            var responseReader = new ResponseReader(_session, edmModel);
+            var result = (await responseReader.GetResponseAsync(response)).Feed;
+            var entry = result.Entries.First();
+            Assert.NotNull(entry);
+            Assert.Equal(42m, entry.Data["Id"]);
+            Assert.Equal(43m, entry.Data["IntegerProperty"]);
+            Assert.Null(entry.Data["NullProperty"]);
+            Assert.Equal("some string", entry.Data["StringProperty"]);
+        }
+
+        private new IODataResponseMessageAsync SetUpResourceMock(string resourceName)
+        {
+            var document = GetResourceAsString(resourceName);
+            var mock = new Mock<IODataResponseMessageAsync>();
+            mock.Setup(x => x.GetStreamAsync()).ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(document)));
+            mock.Setup(x => x.GetStream()).Returns(new MemoryStream(Encoding.UTF8.GetBytes(document)));
+            mock.Setup(x => x.GetHeader("Content-Type")).Returns(() => "application/json; type=feed; charset=utf-8");
+            return mock.Object;
+        }
+    }
+}

--- a/src/Simple.OData.Client.UnitTests/Resources/OpenTypeV401.json
+++ b/src/Simple.OData.Client.UnitTests/Resources/OpenTypeV401.json
@@ -1,0 +1,11 @@
+﻿{
+  "@odata.context": "http://localhost/ApiActionExample/odata/$metadata#TheRecords",
+  "value": [
+    {
+      "Id": 42,
+      "IntegerProperty": 43,
+      "NullProperty": null,
+      "StringProperty": "some string"
+    }
+  ]
+}

--- a/src/Simple.OData.Client.UnitTests/Resources/OpenTypes.xml
+++ b/src/Simple.OData.Client.UnitTests/Resources/OpenTypes.xml
@@ -1,0 +1,15 @@
+﻿<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Test.Namespace">
+            <EntityContainer Name="Default">
+                <EntitySet Name="TheRecords" EntityType="Test.Namespace.TheRecord"/>
+            </EntityContainer>
+            <EntityType Name="TheRecord" OpenType="true">
+                <Key>
+                    <PropertyRef Name="Id"/>
+                </Key>
+                <Property Name="Id" Type="Edm.Decimal" Nullable="false"/>
+            </EntityType>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
+++ b/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
@@ -50,6 +50,8 @@
     <None Remove="Resources\Northwind.xml" />
     <None Remove="Resources\Northwind3.xml" />
     <None Remove="Resources\Northwind4.xml" />
+    <None Remove="Resources\OpenTypes.xml" />
+    <None Remove="Resources\OpenTypeV401.json" />
     <None Remove="Resources\QAS.Multiplatform.Demo.edmx" />
     <None Remove="Resources\Russian.xml" />
     <None Remove="Resources\SingleCategoryWithProducts.xml" />
@@ -103,6 +105,8 @@
     <EmbeddedResource Include="Resources\ClientProductSku.xml" />
     <EmbeddedResource Include="Resources\Colors.edmx" />
     <EmbeddedResource Include="Resources\DynamicsCRM.xml" />
+    <EmbeddedResource Include="Resources\OpenTypes.xml" />
+    <EmbeddedResource Include="Resources\OpenTypeV401.json" />
     <EmbeddedResource Include="Resources\ExampleActionComplexType.json" />
     <EmbeddedResource Include="Resources\Facebook.edmx" />
     <EmbeddedResource Include="Resources\Flickr.edmx" />

--- a/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
+++ b/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
@@ -17,6 +17,14 @@ namespace Simple.OData.Client.V4.Adapter
                 readerSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
             readerSettings.MessageQuotas.MaxReceivedMessageSize = int.MaxValue;
             readerSettings.ShouldIncludeAnnotation = x => settings.IncludeAnnotationsInResults;
+
+            if (!settings.ReadUntypedAsString)
+            {
+                readerSettings.Version = ODataVersion.V401;
+                readerSettings.MaxProtocolVersion = ODataVersion.V401;
+                readerSettings.ReadUntypedAsString = false;
+            }
+
             return readerSettings;
         }
     }


### PR DESCRIPTION
When using OData v401 OpenTypes there is the ability to utilize types from a response.
The PR adds the ability to set the flag in settings for Microsoft.Odata.ODataMessageReader to enable that.

