### PR TITLE
Added useful methods to FluentClient

### DIFF
--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -504,9 +504,15 @@ namespace Simple.OData.Client
         /// <returns>Execution result.</returns>
         public Task<T> ExecuteAsSingleAsync()
         {
-            return FilterAndTypeColumnsAsync(
-                _client.ExecuteAsSingleAsync(_command, CancellationToken.None),
-                _command.SelectedColumns, _command.DynamicPropertiesContainerName);
+            return ExecuteAsSingleAsync<T>(CancellationToken.None);
+        }
+        /// <summary>
+        /// Executes the OData function or action and returns a single item.
+        /// </summary>
+        /// <returns>Execution result.</returns>
+        public Task<U> ExecuteAsSingleAsync<U>()
+        {
+            return ExecuteAsSingleAsync<U>(CancellationToken.None);
         }
         /// <summary>
         /// Executes the OData function or action and returns a single item.
@@ -515,9 +521,16 @@ namespace Simple.OData.Client
         /// <returns>Execution result.</returns>
         public Task<T> ExecuteAsSingleAsync(CancellationToken cancellationToken)
         {
-            return FilterAndTypeColumnsAsync(
-                _client.ExecuteAsSingleAsync(_command, cancellationToken),
-                _command.SelectedColumns, _command.DynamicPropertiesContainerName);
+            return ExecuteAsSingleAsync<T>(cancellationToken);
+        }
+        /// <summary>
+        /// Executes the OData function or action and returns a single item.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Execution result.</returns>
+        public async Task<U> ExecuteAsSingleAsync<U>(CancellationToken cancellationToken)
+        {
+            return (await ExecuteAsArrayAsync<U>(cancellationToken)).Single();
         }
 
         /// <summary>
@@ -572,11 +585,30 @@ namespace Simple.OData.Client
         /// <summary>
         /// Executes the OData function and returns an array.
         /// </summary>
+        /// <returns>Execution result.</returns>
+        public Task<T[]> ExecuteAsArrayAsync()
+        {
+            return ExecuteAsArrayAsync<T>(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Executes the OData function and returns an array.
+        /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Execution result.</returns>
         public Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken)
         {
             return _client.ExecuteAsArrayAsync<U>(_command, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the OData function and returns an array.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Execution result.</returns>
+        public Task<T[]> ExecuteAsArrayAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteAsArrayAsync<T>(cancellationToken);
         }
 
         /// <summary>

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -504,7 +504,7 @@ namespace Simple.OData.Client
         /// <returns>Execution result.</returns>
         public Task<T> ExecuteAsSingleAsync()
         {
-            return ExecuteAsSingleAsync<T>(CancellationToken.None);
+            return ExecuteAsSingleAsync(CancellationToken.None);
         }
         /// <summary>
         /// Executes the OData function or action and returns a single item.
@@ -521,7 +521,9 @@ namespace Simple.OData.Client
         /// <returns>Execution result.</returns>
         public Task<T> ExecuteAsSingleAsync(CancellationToken cancellationToken)
         {
-            return ExecuteAsSingleAsync<T>(cancellationToken);
+            return FilterAndTypeColumnsAsync(
+                _client.ExecuteAsSingleAsync(_command, cancellationToken),
+                _command.SelectedColumns, _command.DynamicPropertiesContainerName);
         }
         /// <summary>
         /// Executes the OData function or action and returns a single item.

--- a/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
@@ -406,9 +406,20 @@ namespace Simple.OData.Client
         /// <summary>
         /// Executes the OData function or action.
         /// </summary>
+        /// <returns>Execution result.</returns>
+        Task<U> ExecuteAsSingleAsync<U>();
+        /// <summary>
+        /// Executes the OData function or action.
+        /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Action execution result.</returns>
         Task<T> ExecuteAsSingleAsync(CancellationToken cancellationToken);
+        /// <summary>
+        /// Executes the OData function or action.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Action execution result.</returns>
+        Task<U> ExecuteAsSingleAsync<U>(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the OData function or action and returns collection.
@@ -446,10 +457,23 @@ namespace Simple.OData.Client
         /// <summary>
         /// Executes the OData function or action and returns an array.
         /// </summary>
+        /// <returns>Execution result.</returns>
+        Task<T[]> ExecuteAsArrayAsync();
+
+        /// <summary>
+        /// Executes the OData function or action and returns an array.
+        /// </summary>
         /// <typeparam name="U">The type of the result array.</typeparam>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Action execution result.</returns>
         Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Executes the OData function or action and returns an array.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Action execution result.</returns>
+        Task<T[]> ExecuteAsArrayAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the OData command text.


### PR DESCRIPTION
I've developed a code generator which generates proxy class based on Simple.OData.Client
By generated code we can write followings:
```cs
Client.Customers().GetCustomerById(1).ExecuteAsSingleAsync();
```
instead of
```cs
Client.For<CustomerDto>("Customers").Function("GetCustomerById").Set(new { customerId = 1 }).ExecuteAsSingleAsync();
``` 
In my generated code, Customers() returns ```IBoundClient<CustomerDto>``` and therefor ```GetCustomerById(1).ExecuteAsSingleAsync``` has to return CustomerDto which is fine.

But imaging another method:

```cs
Client.Customers.GetCityOfCustomerById(1)
// equivalent for Client.For<CustomerDto>("Customers").Function"(GetCityOfCustomerById").Set(new { customerId = 1 }).ExecuteAsSingleAsync();
```
Which needs to return CityDto, but when I call ```Client.Customers.GetCityOfCustomerById(1).ExecuteAsSingleAsync```, I can't pass CityDto as type parameter. I need something like this:

```cs
Client.Customers().GetCityOfCustomerById(1).ExecuteAsSingleAsync<CityDto>()
```

Another useful method is ExecuteAsArray without type parameter. Sometimes I need array of customers, but I've to explicitly say it's CustomerDto. By this PR I can write followings:

```cs
Client.Customers().GetActiveCustomers().ExecuteAsArrayAsync();
```
Instead of 
```cs
Client.Customers().GetActiveCustomers().ExecuteAsArrayAsync<CustomerDto>(); // CustomerDto doesn't make much scene here.
```

Thanks for your wonderful library (-: