### PR TITLE
Added annotations to child collections.

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/ResponseNode.cs
+++ b/src/Simple.OData.Client.Core/Adapter/ResponseNode.cs
@@ -18,7 +18,7 @@ namespace Simple.OData.Client
             {
                 return
                     this.Feed != null && this.Feed.Entries !=null
-                    ? (object)this.Feed.Entries.Select(x => x.Data)
+                    ? (object)this.Feed.Entries
                     : this.Entry != null
                     ? this.Entry.Data
                     : null;

--- a/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
@@ -140,7 +140,7 @@ namespace Simple.OData.Client
                             x.Data[FluentCommand.AnnotationsLiteral] = x.Annotations;
                         }
                         return x.Data;
-                    });
+                    }).ToArray();
                 }
 
                 nodeStack.Peek().Entry.Data.Add(linkNode.LinkName, linkValue);

--- a/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
@@ -117,10 +117,10 @@ namespace Simple.OData.Client
         protected void EndNavigationLink(Stack<ResponseNode> nodeStack)
         {
             var linkNode = nodeStack.Pop();
-            if (linkNode.Value != null)
+            var linkValue = linkNode.Value;
+            if (linkValue != null)
             {
-                var linkValue = linkNode.Value;
-                if (linkNode.Value is IDictionary<string, object> d)
+                if (linkValue is IDictionary<string, object> d)
                 {
                     if (!d.Any())
                     {
@@ -130,6 +130,17 @@ namespace Simple.OData.Client
                     {
                         d[FluentCommand.AnnotationsLiteral] = linkNode.Entry.Annotations;
                     }
+                }
+                else if (linkValue is IEnumerable<AnnotatedEntry> annotatedEntries)
+                {
+                    linkValue = annotatedEntries.Select(x =>
+                    {
+                        if (_session.Settings.IncludeAnnotationsInResults)
+                        {
+                            x.Data[FluentCommand.AnnotationsLiteral] = x.Annotations;
+                        }
+                        return x.Data;
+                    });
                 }
 
                 nodeStack.Peek().Entry.Data.Add(linkNode.LinkName, linkValue);


### PR DESCRIPTION
Annotations are not included in collection navigations. Example:

```csharp
public class Parent
{
    public Child[] Children { get; set; }
}

public class Child
{
}

client.For<Parent>().Expand(x => x.Children)[...];
```


The annotations are not included for each child, even if `IncludeAnnotationsInResults` is set to true. This PR fixes that.