### PR TITLE
Fix issue #485

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
@@ -35,13 +35,14 @@ namespace Simple.OData.Client
                 {
                     var actionResponse = batchResponse.Batch[responseIndex];
                     if (actionResponse.Exception != null)
-                    {
-                        exceptions.Add(actionResponse.Exception);
-                    }
-                    else if (actionResponse.StatusCode >= (int)HttpStatusCode.BadRequest)
-                    {
-                        exceptions.Add(WebRequestException.CreateFromStatusCode((HttpStatusCode)actionResponse.StatusCode));
-                    }
+                        if (actionResponse.StatusCode == (int)HttpStatusCode.NotFound && _session.Settings.IgnoreResourceNotFoundException)
+                        {
+                            await actions[actionIndex](new ODataClient(client as ODataClient, actionResponse)).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            exceptions.Add(actionResponse.Exception);
+                        }
                     else
                     {
                         await actions[actionIndex](new ODataClient(client as ODataClient, actionResponse)).ConfigureAwait(false);


### PR DESCRIPTION
- Allow processing of batch requests to continue if IgnoreResourceNotFoundException property is true and batch request returns 404.

- Also removed a redundant 'else if' block. From what I can tell, an actionResponse that has a statusCode >= 400 will always have an Exception attached. So there is no need to check for a statusCode >= 400 after we have confirmed that there is no exception. 

- Added a test for the continuation of batch processing.

Ticket Link:
https://github.com/simple-odata-client/Simple.OData.Client/issues/485