### PR TITLE
allow reading Location and OData-EntityId header from batches

### DIFF
--- a/src/Simple.OData.Client.Core/IODataClient.cs
+++ b/src/Simple.OData.Client.Core/IODataClient.cs
@@ -600,5 +600,7 @@ namespace Simple.OData.Client
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Action execution result.</returns>
         Task<T[]> ExecuteActionAsArrayAsync<T>(string actionName, IDictionary<string, object> parameters, CancellationToken cancellationToken);
+        Task<ODataResponse> GetResponseAsync(ODataRequest request);
+        Task<ODataResponse> GetResponseAsync(ODataRequest request, CancellationToken cancellationToken);
     }
 }

--- a/src/Simple.OData.Client.IntegrationTests/BatchODataTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/BatchODataTests.cs
@@ -225,5 +225,46 @@ namespace Simple.OData.Client.Tests
             Assert.True(milk.ContainsKey("ID"));
         }
 
+        [Fact]
+        public async Task InsertWithoutResultsReadingLocationHeader()
+        {
+            const int id = 5897;
+            ODataResponse response = null;
+            var batch = new ODataBatch(_serviceUri);
+            batch += async x =>
+            {
+                var request = x.For("Products")
+                    .Set(CreateProduct(id, "Test"))
+                    .BuildRequestFor()
+                    .InsertEntryAsync(false)
+                    .Result
+                    .GetRequest();
+                response = await x.GetResponseAsync(request);
+            };
+            await batch.ExecuteAsync();
+            Assert.NotNull(response);
+            Assert.Equal($"{_serviceUri}Products({id})", response.Location);
+        }
+
+        [Fact]
+        public async Task InsertReadingLocationHeader()
+        {
+            const int id = 5898;
+            ODataResponse response = null;
+            var batch = new ODataBatch(_serviceUri);
+            batch += async x =>
+            {
+                var request = x.For("Products")
+                    .Set(CreateProduct(id, "Test"))
+                    .BuildRequestFor()
+                    .InsertEntryAsync(true)
+                    .Result
+                    .GetRequest();
+                response = await x.GetResponseAsync(request);
+            };
+            await batch.ExecuteAsync();
+            Assert.NotNull(response);
+            Assert.Equal($"{_serviceUri}Products({id})", response.Location);
+        }
     }
 }

--- a/src/Simple.OData.Client.IntegrationTests/InsertODataTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/InsertODataTests.cs
@@ -104,5 +104,33 @@ namespace Simple.OData.Client.Tests
             Assert.NotNull(product[ProductCategoryName]);
             Assert.Equal(category["ID"], ProductCategoryFunc(product)["ID"]);
         }
+
+        [Fact]
+        public async Task InsertReadingLocationHeader()
+        {
+            const int id = 5899;
+            var withRequest = await _client
+                .For("Products")
+                .Set(CreateProduct(id, "Test"))
+                .BuildRequestFor()
+                .InsertEntryAsync();
+            var response = await _client.GetResponseAsync(withRequest.GetRequest());
+            Assert.NotNull(response);
+            Assert.Equal($"{_serviceUri}Products({id})", response.Location);
+        }
+
+        [Fact]
+        public async Task InsertWithoutResultsReadingLocationHeader()
+        {
+            const int id = 5900;
+            var withRequest = await _client
+                .For("Products")
+                .Set(CreateProduct(id, "Test"))
+                .BuildRequestFor()
+                .InsertEntryAsync(false);
+            var response = await _client.GetResponseAsync(withRequest.GetRequest());
+            Assert.NotNull(response);
+            Assert.Equal($"{_serviceUri}Products({id})", response.Location);
+        }
     }
 }


### PR DESCRIPTION
When inserting data I like to use `Prefer=minimal` and just get the entity id from the `Location` or `OData-EntityId` headers. I could not find a way to do this for batch requests. For normal requests one could use `BuildRequestFor` and execute the request yourself using `IClientWithRequest` and `IClientWithResponse` to get the response.
I added a slightly easier way that also works in batch requests.