### PR TITLE
 Add support to delete references between entities by absolute URIs

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -258,6 +258,15 @@ namespace Simple.OData.Client
         public ODataTrace TraceFilter { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether reference uris should be written as absolute uris instead of relative uris.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to extend reference links to absolute uris; otherwise, <c>false</c>.
+        /// </value>
+        /// <summary>
+        public bool UseAbsoluteReferenceUris { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ODataClientSettings"/> class.
         /// </summary>
         public ODataClientSettings()
@@ -333,6 +342,7 @@ namespace Simple.OData.Client
             this.AfterResponseAsync = session.Settings.AfterResponseAsync;
             this.OnTrace = session.Settings.OnTrace;
             this.TraceFilter = session.Settings.TraceFilter;
+            this.UseAbsoluteReferenceUris = session.Settings.UseAbsoluteReferenceUris;
         }
     }
 }

--- a/src/Simple.OData.Client.UnitTests/BasicApi/ClientReadWriteTests.cs
+++ b/src/Simple.OData.Client.UnitTests/BasicApi/ClientReadWriteTests.cs
@@ -122,10 +122,14 @@ namespace Simple.OData.Client.Tests.BasicApi
             Assert.Null(ship);
         }
 
-        [Fact]
-        public async Task LinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client.InsertEntryAsync("Categories", new Entry() { { "CategoryName", "Test4" } }, true);
             var product = await client.InsertEntryAsync("Products", new Entry() { { "ProductName", "Test5" } }, true);
 
@@ -136,10 +140,14 @@ namespace Simple.OData.Client.Tests.BasicApi
             Assert.Equal(category["CategoryID"], product["CategoryID"]);
         }
 
-        [Fact]
-        public async Task UnlinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UnlinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client.InsertEntryAsync("Categories", new Entry() { { "CategoryName", "Test6" } }, true);
             var product = await client.InsertEntryAsync("Products", new Entry() { { "ProductName", "Test7" }, { "CategoryID", category["CategoryID"] } }, true);
             product = await client.FindEntryAsync("Products?$filter=ProductName eq 'Test7'");

--- a/src/Simple.OData.Client.UnitTests/FluentApi/BatchTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/BatchTests.cs
@@ -376,10 +376,13 @@ namespace Simple.OData.Client.Tests.FluentApi
             Assert.Equal(1, result);
         }
 
-        [Fact]
-        public async Task LinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkEntry(bool useAbsoluteReferenceUris)
         {
             var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
             var client = new ODataClient(settings);
             var category = await client
                 .For("Categories")

--- a/src/Simple.OData.Client.UnitTests/FluentApi/LinkDynamicTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/LinkDynamicTests.cs
@@ -5,11 +5,15 @@ namespace Simple.OData.Client.Tests.FluentApi
 {
     public class LinkDynamicTests : TestBase
     {
-        [Fact]
-        public async Task LinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
-            var x = ODataDynamic.Expression;
+                var settings = CreateDefaultSettings().WithHttpMock();
+                settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+                var client = new ODataClient(settings);
+                var x = ODataDynamic.Expression;
             var category = await client
                 .For(x.Categories)
                 .Set(x.CategoryName = "Test4")
@@ -32,10 +36,14 @@ namespace Simple.OData.Client.Tests.FluentApi
             Assert.Equal(category.CategoryID, product.CategoryID);
         }
 
-        [Fact]
-        public async Task UnlinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UnlinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var x = ODataDynamic.Expression;
             var category = await client
                 .For(x.Categories)

--- a/src/Simple.OData.Client.UnitTests/FluentApi/LinkTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/LinkTests.cs
@@ -5,10 +5,14 @@ namespace Simple.OData.Client.Tests.FluentApi
 {
     public class LinkTests : TestBase
     {
-        [Fact]
-        public async Task LinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client
                 .For("Categories")
                 .Set(new { CategoryName = "Test4" })
@@ -31,10 +35,14 @@ namespace Simple.OData.Client.Tests.FluentApi
             Assert.Equal(category["CategoryID"], product["CategoryID"]);
         }
 
-        [Fact]
-        public async Task UnlinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UnlinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client
                 .For("Categories")
                 .Set(new { CategoryName = "Test4" })

--- a/src/Simple.OData.Client.UnitTests/FluentApi/LinkTypedTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/LinkTypedTests.cs
@@ -5,10 +5,14 @@ namespace Simple.OData.Client.Tests.FluentApi
 {
     public class LinkTypedTests : TestBase
     {
-        [Fact]
-        public async Task LinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client
                 .For<Category>()
                 .Set(new { CategoryName = "Test4" })
@@ -31,10 +35,14 @@ namespace Simple.OData.Client.Tests.FluentApi
             Assert.Equal(category.CategoryID, product.CategoryID);
         }
 
-        [Fact]
-        public async Task UnlinkEntry()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UnlinkEntry(bool useAbsoluteReferenceUris)
         {
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            var settings = CreateDefaultSettings().WithHttpMock();
+            settings.UseAbsoluteReferenceUris = useAbsoluteReferenceUris;
+            var client = new ODataClient(settings);
             var category = await client
                 .For<Category>()
                 .Set(new { CategoryName = "Test4" })

--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -150,7 +150,7 @@ namespace Simple.OData.Client.V4.Adapter
         protected override async Task<Stream> WriteLinkContentAsync(string method, string commandText, string linkIdent)
         {
             var message = IsBatch
-                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false).ConfigureAwait(false) 
+                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false).ConfigureAwait(false)
                 : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
@@ -304,7 +304,7 @@ namespace Simple.OData.Client.V4.Adapter
         {
             return linkIdent == null
                 ? $"{entryIdent}/{navigationPropertyName}/$ref"
-                : $"{entryIdent}/{navigationPropertyName}/$ref?$id={linkIdent}";
+                : $"{entryIdent}/{navigationPropertyName}/$ref?$id={(_session.Settings.UseAbsoluteReferenceUris ? _session.Settings.BaseUri.AbsoluteUri + linkIdent : linkIdent)}";
         }
 
         protected override void AssignHeaders(ODataRequest request)
@@ -406,8 +406,8 @@ namespace Simple.OData.Client.V4.Adapter
             root = root ?? entry;
 
             var entryType = _model.FindDeclaredType(entry.TypeName);
-            var typeProperties = typeof(IEdmEntityType).IsTypeAssignableFrom(entryType.GetType()) 
-                ? (entryType as IEdmEntityType).Properties().ToList() 
+            var typeProperties = typeof(IEdmEntityType).IsTypeAssignableFrom(entryType.GetType())
+                ? (entryType as IEdmEntityType).Properties().ToList()
                 : (entryType as IEdmComplexType).Properties().ToList();
 
             string findMatchingPropertyName(string name)
@@ -422,21 +422,21 @@ namespace Simple.OData.Client.V4.Adapter
                 return property?.Type;
             }
 
-            bool isStructural(IEdmTypeReference type) => 
+            bool isStructural(IEdmTypeReference type) =>
                 type != null && type.TypeKind() == EdmTypeKind.Complex;
-            bool isStructuralCollection(IEdmTypeReference type) => 
+            bool isStructuralCollection(IEdmTypeReference type) =>
                 type != null && type.TypeKind() == EdmTypeKind.Collection && type.AsCollection().ElementType().TypeKind() == EdmTypeKind.Complex;
-            bool isPrimitive(IEdmTypeReference type) => 
+            bool isPrimitive(IEdmTypeReference type) =>
                 !isStructural(type) && !isStructuralCollection(type);
 
             var resourceEntry = new ResourceProperties(entry);
             entry.Properties = properties
                 .Where(x => isPrimitive(findMatchingPropertyType(x.Key)))
                 .Select(x => new ODataProperty
-            {
-                Name = findMatchingPropertyName(x.Key),
-                Value = GetPropertyValue(typeProperties, x.Key, x.Value, root)
-            }).ToList();
+                {
+                    Name = findMatchingPropertyName(x.Key),
+                    Value = GetPropertyValue(typeProperties, x.Key, x.Value, root)
+                }).ToList();
             resourceEntry.CollectionProperties = properties
                 .Where(x => isStructuralCollection(findMatchingPropertyType(x.Key)))
                 .Select(x => new KeyValuePair<string, ODataCollectionValue>(
@@ -451,7 +451,7 @@ namespace Simple.OData.Client.V4.Adapter
                 .ToDictionary();
             _resourceEntryMap.Add(entry, resourceEntry);
             if (root != null && _resourceEntries.TryGetValue(root, out var entries))
-                    entries.Add(entry);
+                entries.Add(entry);
 
             return entry;
         }

--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -150,7 +150,7 @@ namespace Simple.OData.Client.V4.Adapter
         protected override async Task<Stream> WriteLinkContentAsync(string method, string commandText, string linkIdent)
         {
             var message = IsBatch
-                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false).ConfigureAwait(false)
+                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false).ConfigureAwait(false) 
                 : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
@@ -406,8 +406,8 @@ namespace Simple.OData.Client.V4.Adapter
             root = root ?? entry;
 
             var entryType = _model.FindDeclaredType(entry.TypeName);
-            var typeProperties = typeof(IEdmEntityType).IsTypeAssignableFrom(entryType.GetType())
-                ? (entryType as IEdmEntityType).Properties().ToList()
+            var typeProperties = typeof(IEdmEntityType).IsTypeAssignableFrom(entryType.GetType()) 
+                ? (entryType as IEdmEntityType).Properties().ToList() 
                 : (entryType as IEdmComplexType).Properties().ToList();
 
             string findMatchingPropertyName(string name)
@@ -422,21 +422,21 @@ namespace Simple.OData.Client.V4.Adapter
                 return property?.Type;
             }
 
-            bool isStructural(IEdmTypeReference type) =>
+            bool isStructural(IEdmTypeReference type) => 
                 type != null && type.TypeKind() == EdmTypeKind.Complex;
-            bool isStructuralCollection(IEdmTypeReference type) =>
+            bool isStructuralCollection(IEdmTypeReference type) => 
                 type != null && type.TypeKind() == EdmTypeKind.Collection && type.AsCollection().ElementType().TypeKind() == EdmTypeKind.Complex;
-            bool isPrimitive(IEdmTypeReference type) =>
+            bool isPrimitive(IEdmTypeReference type) => 
                 !isStructural(type) && !isStructuralCollection(type);
 
             var resourceEntry = new ResourceProperties(entry);
             entry.Properties = properties
                 .Where(x => isPrimitive(findMatchingPropertyType(x.Key)))
                 .Select(x => new ODataProperty
-                {
-                    Name = findMatchingPropertyName(x.Key),
-                    Value = GetPropertyValue(typeProperties, x.Key, x.Value, root)
-                }).ToList();
+            {
+                Name = findMatchingPropertyName(x.Key),
+                Value = GetPropertyValue(typeProperties, x.Key, x.Value, root)
+            }).ToList();
             resourceEntry.CollectionProperties = properties
                 .Where(x => isStructuralCollection(findMatchingPropertyType(x.Key)))
                 .Select(x => new KeyValuePair<string, ODataCollectionValue>(
@@ -451,7 +451,7 @@ namespace Simple.OData.Client.V4.Adapter
                 .ToDictionary();
             _resourceEntryMap.Add(entry, resourceEntry);
             if (root != null && _resourceEntries.TryGetValue(root, out var entries))
-                entries.Add(entry);
+                    entries.Add(entry);
 
             return entry;
         }


### PR DESCRIPTION
This PR closes #441, closes #194

Unlinking references in OData v2 and v3 endpoints is quite different to v4 and v4.01 endpoints. While versions before v4 using the `http://host/service/$links/NavigationProperty` template, versions of v4 or v4.01 must implement this `http://host/service/Entity(id)/NavigationProperty/$ref` template to address entity references. On top of that, there are two different ways to delete **collection** of references:

1. `DELETE http://host/service/Categories(1)/Products/$ref?$id=../../Products(0)`
1. `DELETE http://host/service/Products(0)/Category/$ref`

The spec of [Odata v4.0 - 4.4](https://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752345) contains the following text:

> Resource paths addressing collection of references can be used in DELETE requests if they are followed by the system query option $id identifying one of the entity references in the collection. **The entity-id specified by $id may be expressed absolute or relative to the request URL.**

The Simple OData Client only supports the last (relative uris) option. This PR adds a way to support the first (absolute uris) option too as an opt-in (no breaking change)by just setting a new simple `bool UseAbsoluteReferenceUris` property of the `ODataClientSettings` to `true`.

_Additional Information_

This PR is relevant because OData + ASP.NET Core apps actually doesn't support relative URIs and it can be used as a workaround until [this issue](https://github.com/OData/WebApi/issues/869) is fixed.