### PR TITLE
Fix possible missing slashes

### DIFF
--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -302,9 +302,16 @@ namespace Simple.OData.Client.V4.Adapter
 
         protected override string FormatLinkPath(string entryIdent, string navigationPropertyName, string linkIdent = null)
         {
-            return linkIdent == null
-                ? $"{entryIdent}/{navigationPropertyName}/$ref"
-                : $"{entryIdent}/{navigationPropertyName}/$ref?$id={(_session.Settings.UseAbsoluteReferenceUris ? _session.Settings.BaseUri.AbsoluteUri + linkIdent : linkIdent)}";
+            var linkPath = $"{entryIdent}/{navigationPropertyName}/$ref";
+            if (linkIdent != null)
+            {
+                var link = _session.Settings.UseAbsoluteReferenceUris
+                    ? Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkIdent).AbsoluteUri
+                    : linkIdent;
+                linkPath += $"?$id={link}";
+            }
+
+            return linkPath;
         }
 
         protected override void AssignHeaders(ODataRequest request)


### PR DESCRIPTION
This PR makes sure that a trailing slash `/` always exists at the end of `_session.Settings.BaseUri.AbsoluteUri` when using absolute reference URIs to keep a valid URL.

Thanks @lordmampf :)