### PR TITLE
$select inside $expand example

### DIFF
--- a/src/Simple.OData.Client.IntegrationTests/TripPinEntities.cs
+++ b/src/Simple.OData.Client.IntegrationTests/TripPinEntities.cs
@@ -31,7 +31,7 @@ namespace Simple.OData.Client.Tests
     {
         public IEnumerable<Person> Friends { get; set; }
         public IEnumerable<Trip> Trips { get; set; }
-        public IEnumerable<Photo> Photos { get; set; }
+        public Photo Photo { get; set; }
     }
 
     class PersonWithDateTime : PersonBase

--- a/src/Simple.OData.Client.IntegrationTests/TripPinTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/TripPinTests.cs
@@ -363,6 +363,20 @@ namespace Simple.OData.Client.Tests
         }
 
         [Fact]
+        public async Task FindPersonExpandFriendsWithSelect()
+        {
+            var persons = await _client
+                .For<Person>()
+                .Expand(x => x.Friends)
+                .Select(x => new {x.UserName, Friends = x.Friends.Select(y=>y.UserName)})
+                .Top(1)
+                .FindEntriesAsync();
+            var person = Assert.Single(persons);
+            Assert.DoesNotContain(person.Friends, x =>x.UserName == null);
+            Assert.True(person.Friends.All(x=>x.FirstName == null));
+        }
+
+        [Fact]
         public async Task FindPersonFlightsWithFilter()
         {
             var flights = await _client

--- a/src/Simple.OData.Client.IntegrationTests/TripPinTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/TripPinTests.cs
@@ -126,7 +126,7 @@ namespace Simple.OData.Client.Tests
                 .FindEntryAsync();
             Assert.Empty(person.Trips);
             Assert.Null(person.Friends);
-            Assert.Null(person.Photos);
+            Assert.Null(person.Photo);
         }
 
         [Fact]
@@ -346,6 +346,20 @@ namespace Simple.OData.Client.Tests
                 .FindEntriesAsync();
             Assert.Equal(2, flights.Count());
             Assert.Contains(flights, x => x.FlightNumber == "FM1930");
+        }
+
+        [Fact]
+        public async Task FindPersonExpandPhotoWithSelect()
+        {
+            var persons = await _client
+                .For<Person>()
+                .Expand(x => x.Photo)
+                .Select(x => new {x.UserName, Photo = new {x.Photo.Name}})
+                .Top(1)
+                .FindEntriesAsync();
+            var person = Assert.Single(persons);
+            Assert.Null(person.Photo.Media);
+            Assert.Equal(default, person.Photo.Id);
         }
 
         [Fact]


### PR DESCRIPTION
unit test examples for $expand with $select on collection and 1:1 as discussed in #578 and #136
 `$expand=Photo($select=Name)`
`$expand=Friends($select=UserName)`

also fixes the invalid `Person.Photos` reference