### PR TITLE
fix for defect 402 - batch reference

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
@@ -134,9 +134,10 @@ namespace Simple.OData.Client
         public async Task<ODataRequest> CreateUnlinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent)
         {
             var associationName = _session.Metadata.GetNavigationPropertyExactName(collection, linkName);
-            await WriteEntryContentAsync(RestVerbs.Delete, collection, entryIdent, null, false).ConfigureAwait(false);
-
             var commandText = FormatLinkPath(entryIdent, associationName, linkIdent);
+            
+            await WriteEntryContentAsync(RestVerbs.Delete, collection, commandText, null, false).ConfigureAwait(false);
+            
             var request = new ODataRequest(RestVerbs.Delete, _session, commandText)
             {
                 IsLink = true,


### PR DESCRIPTION
Relationship deletes were not being setup correctly when batching.  This is a fix for defect https://github.com/simple-odata-client/Simple.OData.Client/issues/402.