### PR TITLE
Add the possibility to add request query options for all cases

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -39,6 +39,7 @@ namespace Simple.OData.Client
             if (command.HasKey)
                 commandText += ConvertKeyValuesToUriLiteral(command.KeyValues, true);
 
+            var collectionValues = new List<string>();
             if (!string.IsNullOrEmpty(command.Details.MediaName))
             {
                 commandText += "/" + (command.Details.MediaName == FluentCommand.MediaEntityLiteral
@@ -57,7 +58,6 @@ namespace Simple.OData.Client
                         commandText += _session.Metadata.GetActionFullName(command.Details.ActionName);
                 }
 
-                var collectionValues = new List<string>();
                 if (!string.IsNullOrEmpty(command.Details.FunctionName) && FunctionFormat == FunctionFormat.Key)
                     commandText += ConvertKeyValuesToUriLiteralExtractCollections(command.CommandData, collectionValues, false);
 
@@ -65,10 +65,9 @@ namespace Simple.OData.Client
                 {
                     commandText += "/" + _session.Metadata.GetQualifiedTypeName(command.Details.DerivedCollectionName);
                 }
-
-                commandText += FormatClauses(command, collectionValues);
             }
 
+            commandText += FormatClauses(command, collectionValues);
             return commandText;
         }
 
@@ -112,7 +111,7 @@ namespace Simple.OData.Client
                 if (item.Value != null)
                 {
                     var itemType = item.Value.GetType();
-                    if (itemType.IsArray || TypeCache.IsGeneric(itemType) && TypeCache.IsTypeAssignableFrom(typeof(System.Collections.IEnumerable),itemType))
+                    if (itemType.IsArray || TypeCache.IsGeneric(itemType) && TypeCache.IsTypeAssignableFrom(typeof(System.Collections.IEnumerable), itemType))
                     {
                         var itemAlias = $"@p{++colIndex}";
                         var collection = item.Value as System.Collections.IEnumerable;

--- a/src/Simple.OData.Client.UnitTests/Core/StreamTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/StreamTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Simple.OData.Client.Tests.Core
@@ -21,9 +22,10 @@ namespace Simple.OData.Client.Tests.Core
             var command = _client
                 .For<Photo>()
                 .Key(1)
+                .QueryOptions(new Dictionary<string, object>() { { "IntOption", 42 }, { "StringOption", "xyz" } })
                 .Media();
             var commandText = await command.GetCommandTextAsync();
-            Assert.Equal("Photos(1)/$value", commandText);
+            Assert.Equal("Photos(1)/$value?IntOption=42&StringOption='xyz'", commandText);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #645 and fixes #499 and allows adding query options (including [Custom Query Options](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc26180032)) for all cases.

It means that a user can easier create queries which would not work. On the other hand the user were never noticed about automatically removed query options before. Both options have pros and cons but I tend to the first one, because this is the correct solution: Query options should always be allowed for RESTful APIs as well as for OData APIs.

What do you think?