### PR TITLE
Make ODataClientSettings readonly accessable

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClient.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.cs
@@ -15,6 +15,9 @@ namespace Simple.OData.Client
         private readonly Lazy<IBatchWriter> _lazyBatchWriter;
         private readonly ConcurrentDictionary<object, IDictionary<string, object>> _batchEntries;
         private readonly ODataResponse _batchResponse;
+        
+        // Allows access for unit tests
+        public ODataClientSettings ClientSettings { get => _settings; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataClient"/> class.


### PR DESCRIPTION
To create an unit test to check if settings were correctly set/applied, I've created a public readonly property. I want to use it, when I write a wrapper to create an ODataClient object and configure it within that wrapper method.
Currently it's not possible to check if the return Result (ODataClient) is correctly configured.