### PR TITLE
Add support for System.Text.Json JsonPropertyName mapping

### DIFF
--- a/src/Simple.OData.Client.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/MemberInfoExtensions.cs
@@ -64,6 +64,7 @@ namespace Simple.OData.Client.Extensions
                 "DataMemberAttribute",
                 "ColumnAttribute",
                 "JsonPropertyAttribute",
+                "JsonPropertyNameAttribute",
             };
 
             var mappingAttribute = attributes.FirstOrDefault(x => supportedAttributeNames.Any(y => x.GetType().Name == y));

--- a/src/Simple.OData.Client.UnitTests/Core/TypedExpressionsTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/TypedExpressionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 using Newtonsoft.Json;
 using Xunit;
@@ -61,6 +61,8 @@ namespace Simple.OData.Client.Tests.Core
             public string MappedNameUsingDataMemberAndOtherAttribute { get; set; }
             [JsonProperty("Name")]
             public string MappedNameUsingJsonPropertyAttribute { get; set; }
+            [System.Text.Json.Serialization.JsonPropertyName("Name")]
+            public string MappedNameUsingJsonPropertyNameAttribute { get; set; }
         }
 
         [Fact]
@@ -478,6 +480,13 @@ namespace Simple.OData.Client.Tests.Core
         public void FilterWithMappedPropertiesUsingJsonPropertyAttribute()
         {
             Expression<Func<TestEntity, bool>> filter = x => x.MappedNameUsingJsonPropertyAttribute == "Milk";
+            Assert.Equal("Name eq 'Milk'", ODataExpression.FromLinqExpression(filter).AsString(_session));
+        }
+
+        [Fact]
+        public void FilterWithMappedPropertiesUsingJsonPropertyNameAttribute()
+        {
+            Expression<Func<TestEntity, bool>> filter = x => x.MappedNameUsingJsonPropertyNameAttribute == "Milk";
             Assert.Equal("Name eq 'Milk'", ODataExpression.FromLinqExpression(filter).AsString(_session));
         }
 

--- a/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
+++ b/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
@@ -78,6 +78,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Net.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR contains change supporting JsonPropertyNameAttribute from the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json/) package. In the unit test, I purposely fully qualified the attribute instead of adding a ```using``` statement so that it was clear this was from the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json/) package.  I wanted to add a test for the [JsonIgnoreAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonignoreattribute?view=netcore-3.1) however, I was not able to find the tests.  Since the attribute name is the same between [System.Text.Json](https://www.nuget.org/packages/System.Text.Json/) and [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) I would assume it will work without changes.