### PR TITLE
Automatic subtype resolution based on ODataAnnotations/TypeCache

### DIFF
--- a/src/Simple.OData.Client.Core/Cache/ITypeCache.cs
+++ b/src/Simple.OData.Client.Core/Cache/ITypeCache.cs
@@ -44,6 +44,18 @@ namespace Simple.OData.Client
         string DynamicContainerName(Type type);
 
         /// <summary>
+        /// Get the OData annotations property if any.
+        /// </summary>
+        PropertyInfo GetAnnotationsProperty(Type type);
+
+        /// <summary>
+        /// Get all derived types in the same assembly.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        IEnumerable<Type> GetDerivedTypes(Type type);
+
+        /// <summary>
         /// Get the mapped properties for a type
         /// </summary>
         /// <param name="type"></param>

--- a/src/Simple.OData.Client.Core/Cache/TypeCacheExtensions.cs
+++ b/src/Simple.OData.Client.Core/Cache/TypeCacheExtensions.cs
@@ -30,16 +30,14 @@ namespace Simple.OData.Client.Extensions
             throw new FormatException($"Unable to convert value from type {value.GetType()} to type {targetType}");
         }
 
+        [Obsolete("Use ITypeCache.TryConvert")]
         public static bool TryConvert(this ITypeCache typeCache, object value, Type targetType, out object result)
         {
             try
             {
                 if (value == null)
                 {
-                    if (typeCache.IsValue(targetType))
-                        result = Activator.CreateInstance(targetType);
-                    else
-                        result = null;
+                    result = typeCache.IsValue(targetType) ? Activator.CreateInstance(targetType) : null;
                 }
                 else if (typeCache.IsTypeAssignableFrom(targetType, value.GetType()))
                 {

--- a/src/Simple.OData.Client.Core/Cache/TypeCacheResolver.cs
+++ b/src/Simple.OData.Client.Core/Cache/TypeCacheResolver.cs
@@ -20,11 +20,12 @@ namespace Simple.OData.Client
         /// <param name="nameMatchResolver">Name match resolver.</param>
         /// <param name="dynamicType">Whether the cached type is dynamic.</param>
         /// <param name="dynamicContainerName">Dynamic container name.</param>
-        public TypeCacheResolver(Type type, INameMatchResolver nameMatchResolver = null, bool dynamicType = false, string dynamicContainerName = "DynamicProperties")
+        public TypeCacheResolver(Type type, INameMatchResolver nameMatchResolver, bool dynamicType = false, string dynamicContainerName = "DynamicProperties")
         {
             _nameMatchResolver = nameMatchResolver;
 
             Type = type;
+            DerivedTypes = type.DerivedTypes().ToList();
             IsDynamicType = dynamicType;
             DynamicPropertiesName = dynamicContainerName;
             TypeInfo = type.GetTypeInfo();
@@ -37,12 +38,18 @@ namespace Simple.OData.Client
             MappedPropertiesWithNames = type.GetMappedPropertiesWithNames().ToList();
 
             IsAnonymousType = type.IsAnonymousType();
+            AnnotationsProperty = AllProperties.FirstOrDefault(x => x.PropertyType == typeof(ODataEntryAnnotations));
         }
 
         /// <summary>
         /// Gets the type we are responsible for.
         /// </summary>
         public Type Type { get; }
+
+        /// <summary>
+        /// Get all derived types in the same assembly.
+        /// </summary>
+        public IList<Type> DerivedTypes { get; }
 
         public TypeInfo TypeInfo { get; }
 
@@ -116,6 +123,8 @@ namespace Simple.OData.Client
         /// Gets mapped properties with the mapped name
         /// </summary>
         public IList<Tuple<PropertyInfo, string>> MappedPropertiesWithNames { get; }
+
+        public PropertyInfo AnnotationsProperty { get; }
 
         /// <summary>
         /// Gets a mapped property

--- a/src/Simple.OData.Client.UnitTests/Extensions/DictionaryExtensionsTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Extensions/DictionaryExtensionsTests.cs
@@ -337,6 +337,62 @@ namespace Simple.OData.Client.Tests.Extensions
             Assert.Equal(2d, value.PointV4.Longitude);
         }
 
+        [Fact]
+        public void ToObjectBaseType_NoType()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "TransportID", 1 },
+            };
+
+            var value = dict.ToObject<Transport>(_typeCache);
+            Assert.Equal(1, value.TransportID);
+        }
+
+        [Fact]
+        public void ToObjectBaseType_Type()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { FluentCommand.AnnotationsLiteral, new ODataEntryAnnotations { TypeName = "Northwind.Transport" }} ,
+                { "TransportID", 1 },
+            };
+
+            var value = dict.ToObject<Transport>(_typeCache);
+            Assert.Equal(1, value.TransportID);
+        }
+
+        [Fact]
+        public void ToObjectBaseType_SubType()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { FluentCommand.AnnotationsLiteral, new ODataEntryAnnotations { TypeName = "Northwind.Ship" } },
+                { "TransportID", 1 },
+                { "ShipName", "Sloop John B" },
+            };
+
+            var value = dict.ToObject<Transport>(_typeCache);
+            var ship = value as Ship;
+            Assert.NotNull(ship);
+            Assert.Equal(1, ship.TransportID);
+            Assert.Equal("Sloop John B", ship.ShipName);
+        }
+
+        [Fact]
+        public void ToObjectBaseType_MissingSubType()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { FluentCommand.AnnotationsLiteral, new ODataEntryAnnotations { TypeName = "Northwind.Plane" } },
+                { "TransportID", 1 },
+                { "PlaneName", "Concorde" },
+            };
+
+            var value = dict.ToObject<Transport>(_typeCache);
+            Assert.Equal(1, value.TransportID);
+        }
+
         class ClassNoDefaultConstructor
         {
             public ClassNoDefaultConstructor(string arg) {}

--- a/src/Simple.OData.Client.UnitTests/Extensions/TypeCacheTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Extensions/TypeCacheTests.cs
@@ -8,6 +8,12 @@ namespace Simple.OData.Client.Tests.Extensions
         private ITypeCache _typeCache => TypeCaches.TypeCache("test", null);
 
         [Fact]
+        public void GetDerivedTypes_BaseType()
+        {
+            Assert.Single(_typeCache.GetDerivedTypes(typeof(Transport)));
+        }
+
+        [Fact]
         public void GetAllProperties_BaseType()
         {
             Assert.Single(_typeCache.GetAllProperties(typeof(Transport)));

--- a/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
@@ -415,8 +415,10 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .For("Transport")
                 .As("Ships")
                 .FindEntriesAsync();
-            Assert.Equal("Titanic", transport.Single()["ShipName"]);
-            Assert.Equal("NorthwindModel.Ship", (transport.Single()[FluentCommand.AnnotationsLiteral] as ODataEntryAnnotations).TypeName);
+
+            var ship = transport.Single();
+            Assert.Equal("Titanic", ship["ShipName"]);
+            Assert.Equal("NorthwindModel.Ship", (ship[FluentCommand.AnnotationsLiteral] as ODataEntryAnnotations).TypeName);
         }
 
         [Fact]

--- a/src/Simple.OData.Client.UnitTests/FluentApi/FindTypedTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/FindTypedTests.cs
@@ -569,26 +569,22 @@ namespace Simple.OData.Client.Tests.FluentApi
         public async Task BaseClassEntries()
         {
             var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
-            var transport = await client
+            var query = await client
                 .For<Transport>()
                 .FindEntriesAsync();
-            Assert.Equal(2, transport.Count());
+            var transport = query.ToList();
+            Assert.Equal(2, transport.Count);
         }
 
         [Fact]
         public async Task BaseClassEntriesWithAnnotations()
         {
-            var clientSettings = new ODataClientSettings
-            {
-                BaseUri = _serviceUri,
-                IncludeAnnotationsInResults = true,
-            };
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
-            //var client = new ODataClient(clientSettings);
-            var transport = await client
+            var client = new ODataClient(CreateDefaultSettings().WithAnnotations().WithHttpMock());
+            var query = await client
                 .For<Transport>()
                 .FindEntriesAsync();
-            Assert.Equal(2, transport.Count());
+            var transport = query.ToList();
+            Assert.Equal(2, transport.Count);
         }
 
         [Fact]
@@ -605,13 +601,7 @@ namespace Simple.OData.Client.Tests.FluentApi
         [Fact]
         public async Task AllDerivedClassEntriesWithAnnotations()
         {
-            var clientSettings = new ODataClientSettings
-            {
-                BaseUri = _serviceUri,
-                IncludeAnnotationsInResults = true,
-            };
-            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
-            //var client = new ODataClient(clientSettings);
+            var client = new ODataClient(CreateDefaultSettings().WithAnnotations().WithHttpMock());
             var transport = await client
                 .For<Transport>()
                 .As<Ship>()


### PR DESCRIPTION
Extend ToObject to check OData annotations for most appropriate type before deserializing
Extend ITypeCache with GetAnnotationsProperty/GetDerivedTypes