### PR TITLE
Do not send Prefer header on GET/DELETE requests under V4 #600

### DIFF
--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -335,13 +335,18 @@ namespace Simple.OData.Client.V4.Adapter
 
         protected override void AssignHeaders(ODataRequest request)
         {
-            if (request.ResultRequired)
+            // Do not set Prefer headers for GET/DELETE requests per OData spec
+            // http://docs.oasis-open.org/odata/odata/v4.0/os/part1-protocol/odata-v4.0-os-part1-protocol.html#_Toc372793631
+            if ((request.Method != RestVerbs.Get) && (request.Method != RestVerbs.Delete))
             {
-                request.Headers.Add(HttpLiteral.Prefer, HttpLiteral.ReturnRepresentation);
-            }
-            else
-            {
-                request.Headers.Add(HttpLiteral.Prefer, HttpLiteral.ReturnMinimal);
+                if (request.ResultRequired)
+                {
+                    request.Headers.Add(HttpLiteral.Prefer, HttpLiteral.ReturnRepresentation);
+                }
+                else
+                {
+                    request.Headers.Add(HttpLiteral.Prefer, HttpLiteral.ReturnMinimal);
+                }
             }
         }
 


### PR DESCRIPTION
[Per the V4 spec, GET and DELETE requests may not include a `Prefer` header](http://docs.oasis-open.org/odata/odata/v4.0/os/part1-protocol/odata-v4.0-os-part1-protocol.html#_Toc372793631). The V3 spec is less strict and does not explicitly forbid sending them, so I left it alone (perhaps someone relies on this?).

This should resolve #600 and allow headers to be set on GET/DELETE requests in the future (in contrast to #750).

[This is also best viewed with whitespace ignored.](https://github.com/simple-odata-client/Simple.OData.Client/pull/751/files?diff=split&w=1)