### PR TITLE
Handle conversion between Microsoft.OData.Edm.Date and System.DateTime

### DIFF
--- a/src/Simple.OData.Client.Core/Cache/TypeCache.cs
+++ b/src/Simple.OData.Client.Core/Cache/TypeCache.cs
@@ -258,6 +258,10 @@ namespace Simple.OData.Client
                 {
                     result = offset.DateTime;
                 }
+                else if ((targetType == typeof(DateTime) || targetType == typeof(DateTime?)) && value is Microsoft.OData.Edm.Date date)
+                {
+                    result = new DateTime(date.Year, date.Month, date.Day);
+                }
                 else if ((targetType == typeof(DateTimeOffset) || targetType == typeof(DateTimeOffset?)) && value is DateTime time)
                 {
                     result = new DateTimeOffset(time);

--- a/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
+++ b/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.OData.Core" Version="7.6.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Attempt to fix [#243](https://github.com/simple-odata-client/Simple.OData.Client/issues/243) [#736](https://github.com/simple-odata-client/Simple.OData.Client/issues/736) by explicitly handling conversions between Microsoft.OData.Edm.Date and System.DateTime