### PR TITLE
Do not interpret filter of nested entity or complex properties as key

### DIFF
--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.cs
@@ -138,6 +138,7 @@ namespace Simple.OData.Client
             return Format(new ExpressionContext(session));
         }
 
+        private static readonly char[] _propertySeperator = {'.', '/'};
         internal bool ExtractLookupColumns(IDictionary<string, object> lookupColumns)
         {
             switch (_operator)
@@ -156,7 +157,12 @@ namespace Simple.OData.Client
                     }
                     if (!string.IsNullOrEmpty(expr.Reference))
                     {
-                        var key = expr.Reference.Split('.', '/').Last();
+                        if (expr.Reference.IndexOfAny(_propertySeperator) >= 0)
+                        {
+                            //skip child entity - may result in false positives
+                            return false;
+                        }
+                        var key = expr.Reference;
                         if (key != null && !lookupColumns.ContainsKey(key))
                             lookupColumns.Add(key, _right);
                     }

--- a/src/Simple.OData.Client.UnitTests/Core/KeyTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/KeyTests.cs
@@ -125,6 +125,32 @@ namespace Simple.OData.Client.Tests.Core
         }
 
         [Theory]
+        [InlineData("KeyDemo.xml", "Activities?$filter=Ticket%2FId%20eq%201")]
+        public async Task PrimaryKey_SingleProperty_NavigationKeyFilter(string metadataFile, string expectedCommand)
+        {
+            ODataExpression.ArgumentCounter = 0;
+            var client = CreateClient(metadataFile);
+            var command = client
+                .For<Activity>()
+                .Filter(x => x.Ticket.Id == 1);
+            var commandText = await command.GetCommandTextAsync();
+            Assert.Equal(expectedCommand, commandText);
+        }
+
+        [Theory]
+        [InlineData("KeyDemo.xml", "Activities?$filter=Option%2FId%20eq%201")]
+        public async Task PrimaryKey_SingleProperty_ComplexKeyFilter(string metadataFile, string expectedCommand)
+        {
+            ODataExpression.ArgumentCounter = 0;
+            var client = CreateClient(metadataFile);
+            var command = client
+                .For<Activity>()
+                .Filter(x => x.Option.Id == 1);
+            var commandText = await command.GetCommandTextAsync();
+            Assert.Equal(expectedCommand, commandText);
+        }
+
+        [Theory]
         [InlineData("Northwind3.xml", "Categories")]
         [InlineData("Northwind4WithAlternateKeys.xml", "Categories(CategoryName=%27Beverages%27)")]
         public async Task AlternateKey_SingleProperty(string metadataFile, string expectedCommand)

--- a/src/Simple.OData.Client.UnitTests/Entities/Activity.cs
+++ b/src/Simple.OData.Client.UnitTests/Entities/Activity.cs
@@ -1,0 +1,31 @@
+﻿namespace Simple.OData.Client.Tests
+{
+    public class Activity
+    {
+        public long Id { get; set; }
+
+        public string Number { get; set; }
+
+        public string Title { get; set; }
+
+        public Option Option { get; set; }
+
+        public Ticket Ticket { get; set; }
+    }
+
+    public class Ticket
+    {
+        public long Id { get; set; }
+
+        public string Number { get; set; }
+
+        public string Title { get; set; }
+    }
+
+    public class Option
+    {
+        public long Id { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/src/Simple.OData.Client.UnitTests/Resources/KeyDemo.xml
+++ b/src/Simple.OData.Client.UnitTests/Resources/KeyDemo.xml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Demo" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Activity">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Option" Type="Demo.Option" Nullable="false"/>
+        <Property Name="Number" Type="Edm.String"/>
+        <Property Name="Title" Type="Edm.String"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>        
+        <NavigationProperty Name="Ticket" Type="Demo.Ticket"/>
+      </EntityType>
+      <EntityType Name="Ticket">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Number" Type="Edm.String"/>
+        <Property Name="Title" Type="Edm.String"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="Option">
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false"/>
+      </ComplexType>
+    </Schema>
+    <Schema Namespace="Default" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="Container">
+        <EntitySet Name="Activities" EntityType="Demo.Activity"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
+++ b/src/Simple.OData.Client.UnitTests/Simple.OData.Client.UnitTests.csproj
@@ -43,6 +43,7 @@
     <None Remove="Resources\GoogleMaps.edmx" />
     <None Remove="Resources\Insight.edmx" />
     <None Remove="Resources\iPhone.edmx" />
+    <None Remove="Resources\KeyDemo.xml" />
     <None Remove="Resources\Marathon.edmx" />
     <None Remove="Resources\MultipleCategoriesWithProducts.xml" />
     <None Remove="Resources\MultipleProducts.xml" />
@@ -134,6 +135,7 @@
     <EmbeddedResource Include="Resources\SingleProductWithCollectionOfPrimitiveProperties.xml" />
     <EmbeddedResource Include="Resources\SingleProductWithComplexProperty.xml" />
     <EmbeddedResource Include="Resources\SingleProductWithEmptyCollectionOfComplexProperties.xml" />
+    <EmbeddedResource Include="Resources\KeyDemo.xml" />
     <EmbeddedResource Include="Resources\TripPin.xml" />
     <EmbeddedResource Include="Resources\Twitter.edmx" />
     <EmbeddedResource Include="Resources\TwitterStatusesSample.txt" />


### PR DESCRIPTION
The `ExtractLookupColumns` is only used to check if the filter statement can be interpreted as key:
https://github.com/simple-odata-client/Simple.OData.Client/blob/5d2cc4d93fdb98a93e3966d10d1ae5b038017831/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs#L667

fixes #176 