### PR TITLE
Introduce ResolvedCommand

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -32,7 +32,7 @@ namespace Simple.OData.Client
             }
             else if (!string.IsNullOrEmpty(command.Details.LinkName))
             {
-                var parent = new FluentCommand(_session, command.Details.Parent).Resolve(_session);
+                var parent = new FluentCommand(command.Details.Parent).Resolve(_session);
                 commandText += $"{FormatCommand(parent)}/{_session.Metadata.GetNavigationPropertyExactName(parent.EntityCollection.Name, command.Details.LinkName)}";
             }
 

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -32,7 +32,7 @@ namespace Simple.OData.Client
             }
             else if (!string.IsNullOrEmpty(command.Details.LinkName))
             {
-                var parent = new FluentCommand(command.Details.Parent).Resolve();
+                var parent = new FluentCommand(command.Details.Parent).Resolve(_session);
                 commandText += $"{FormatCommand(parent)}/{_session.Metadata.GetNavigationPropertyExactName(parent.EntityCollection.Name, command.Details.LinkName)}";
             }
 

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -177,13 +177,13 @@ namespace Simple.OData.Client
             var details = command.Details;
             if (!ReferenceEquals(details.QueryOptionsExpression, null))
             {
-                queryClauses.Add(details.QueryOptionsExpression.Format(new ExpressionContext(details.Session, true)));
+                queryClauses.Add(details.QueryOptionsExpression.Format(new ExpressionContext(command.Session, true)));
             }
             if (command.Details.QueryOptionsKeyValues != null)
             {
                 foreach (var kv in command.Details.QueryOptionsKeyValues)
                 {
-                    queryClauses.Add($"{kv.Key}={ODataExpression.FromValue(kv.Value).Format(new ExpressionContext(details.Session))}");
+                    queryClauses.Add($"{kv.Key}={ODataExpression.FromValue(kv.Value).Format(new ExpressionContext(command.Session))}");
                 }
             }
 

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -20,7 +20,7 @@ namespace Simple.OData.Client
 
         protected ITypeCache TypeCache => _session.TypeCache;
 
-        public string FormatCommand(FluentCommand command)
+        public string FormatCommand(ResolvedCommand command)
         {
             if (command.HasFunction && command.HasAction)
                 throw new InvalidOperationException("OData function and action may not be combined.");
@@ -142,7 +142,7 @@ namespace Simple.OData.Client
             return "(" + formattedKeyValues + ")";
         }
 
-        protected abstract void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, FluentCommand command);
+        protected abstract void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, ResolvedCommand command);
 
         protected abstract void FormatInlineCount(IList<string> commandClauses);
 
@@ -155,7 +155,7 @@ namespace Simple.OData.Client
                 : text;
         }
 
-        private string FormatClauses(FluentCommand command, IList<string> queryClauses = null)
+        private string FormatClauses(ResolvedCommand command, IList<string> queryClauses = null)
         {
             var text = string.Empty;
             queryClauses = queryClauses ?? new List<string>();

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -22,7 +22,7 @@ namespace Simple.OData.Client
 
         public string FormatCommand(ResolvedCommand command)
         {
-            if (command.HasFunction && command.HasAction)
+            if (command.Details.HasFunction && command.Details.HasAction)
                 throw new InvalidOperationException("OData function and action may not be combined.");
 
             var commandText = string.Empty;
@@ -36,7 +36,7 @@ namespace Simple.OData.Client
                 commandText += $"{FormatCommand(parent)}/{_session.Metadata.GetNavigationPropertyExactName(parent.EntityCollection.Name, command.Details.LinkName)}";
             }
 
-            if (command.HasKey)
+            if (command.Details.HasKey)
                 commandText += ConvertKeyValuesToUriLiteral(command.KeyValues, !command.Details.IsAlternateKey);
 
             var collectionValues = new List<string>();
@@ -194,11 +194,11 @@ namespace Simple.OData.Client
                 queryClauses.Add($"{ODataLiteral.Top}={command.Details.TopCount}");
 
             EntityCollection resultCollection;
-            if (command.HasFunction)
+            if (command.Details.HasFunction)
             {
                 resultCollection = _session.Adapter.GetMetadata().GetFunctionReturnCollection(command.Details.FunctionName);
             }
-            else if (command.HasAction)
+            else if (command.Details.HasAction)
             {
                 resultCollection = _session.Adapter.GetMetadata().GetActionReturnCollection(command.Details.ActionName);
             }

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -177,13 +177,13 @@ namespace Simple.OData.Client
             var details = command.Details;
             if (!ReferenceEquals(details.QueryOptionsExpression, null))
             {
-                queryClauses.Add(details.QueryOptionsExpression.Format(new ExpressionContext(command.Session, true)));
+                queryClauses.Add(details.QueryOptionsExpression.Format(new ExpressionContext(_session, true)));
             }
             if (command.Details.QueryOptionsKeyValues != null)
             {
                 foreach (var kv in command.Details.QueryOptionsKeyValues)
                 {
-                    queryClauses.Add($"{kv.Key}={ODataExpression.FromValue(kv.Value).Format(new ExpressionContext(command.Session))}");
+                    queryClauses.Add($"{kv.Key}={ODataExpression.FromValue(kv.Value).Format(new ExpressionContext(_session))}");
                 }
             }
 

--- a/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/src/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -32,7 +32,7 @@ namespace Simple.OData.Client
             }
             else if (!string.IsNullOrEmpty(command.Details.LinkName))
             {
-                var parent = new FluentCommand(command.Details.Parent).Resolve(_session);
+                var parent = new FluentCommand(_session, command.Details.Parent).Resolve(_session);
                 commandText += $"{FormatCommand(parent)}/{_session.Metadata.GetNavigationPropertyExactName(parent.EntityCollection.Name, command.Details.LinkName)}";
             }
 

--- a/src/Simple.OData.Client.Core/Adapter/ICommandFormatter.cs
+++ b/src/Simple.OData.Client.Core/Adapter/ICommandFormatter.cs
@@ -4,7 +4,7 @@ namespace Simple.OData.Client
 {
     public interface ICommandFormatter
     {
-        string FormatCommand(FluentCommand command);
+        string FormatCommand(ResolvedCommand command);
         string FormatNavigationPath(EntityCollection entityCollection, string path);
         string ConvertKeyValuesToUriLiteral(IDictionary<string, object> key, bool skipKeyNameForSingleValue);
         string ConvertValueToUriLiteral(object value, bool escapeString);

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Simple.OData.Client.Extensions;
 
 namespace Simple.OData.Client
 {

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -44,11 +44,11 @@ namespace Simple.OData.Client
         public async Task<IEnumerable<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
             await _session.ResolveAdapterAsync(cancellationToken);
-            var commandText = await _command.WithCount().Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var command = _command.WithCount().Resolve(_session);
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var result = _client.FindEntriesAsync(commandText, annotations, cancellationToken);
+            var result = _client.FindEntriesAsync(command.Format(), annotations, cancellationToken);
             return await FilterAndTypeColumnsAsync(
                 result, _command.SelectedColumns, _command.DynamicPropertiesContainerName).ConfigureAwait(false);
         }

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -91,7 +91,7 @@ namespace Simple.OData.Client
             var result = await _client.FindScalarAsync(_command, cancellationToken).ConfigureAwait(false);
             return _client.IsBatchRequest 
                 ? default(U) 
-                : _command.TypeCache.Convert<U>(result);
+                : _session.TypeCache.Convert<U>(result);
         }
 
         public Task<T> InsertEntryAsync()
@@ -221,7 +221,7 @@ namespace Simple.OData.Client
 
         public Task LinkEntryAsync<U>(U linkedEntryKey, string linkName, CancellationToken cancellationToken)
         {
-            return _client.LinkEntryAsync(_command, linkName ?? typeof(U).Name, linkedEntryKey.ToDictionary(_command.TypeCache), cancellationToken);
+            return _client.LinkEntryAsync(_command, linkName ?? typeof(U).Name, linkedEntryKey.ToDictionary(_session.TypeCache), cancellationToken);
         }
 
         public Task LinkEntryAsync<U>(Expression<Func<T, U>> expression, U linkedEntryKey)
@@ -231,7 +231,7 @@ namespace Simple.OData.Client
 
         public Task LinkEntryAsync<U>(Expression<Func<T, U>> expression, U linkedEntryKey, CancellationToken cancellationToken)
         {
-            return _client.LinkEntryAsync(_command, ColumnExpression.ExtractColumnName(expression, _command.TypeCache), linkedEntryKey.ToDictionary(_command.TypeCache), cancellationToken);
+            return _client.LinkEntryAsync(_command, ColumnExpression.ExtractColumnName(expression, _session.TypeCache), linkedEntryKey.ToDictionary(_session.TypeCache), cancellationToken);
         }
 
         public Task LinkEntryAsync(ODataExpression expression, IDictionary<string, object> linkedEntryKey)
@@ -246,12 +246,12 @@ namespace Simple.OData.Client
 
         public Task LinkEntryAsync(ODataExpression expression, ODataEntry linkedEntryKey)
         {
-            return _client.LinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey.ToDictionary(_command.TypeCache), CancellationToken.None);
+            return _client.LinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey.ToDictionary(_session.TypeCache), CancellationToken.None);
         }
 
         public Task LinkEntryAsync(ODataExpression expression, ODataEntry linkedEntryKey, CancellationToken cancellationToken)
         {
-            return _client.LinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey.ToDictionary(_command.TypeCache), cancellationToken);
+            return _client.LinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey.ToDictionary(_session.TypeCache), cancellationToken);
         }
 
         public Task UnlinkEntryAsync<U>()
@@ -276,12 +276,12 @@ namespace Simple.OData.Client
 
         public Task UnlinkEntryAsync<U>(Expression<Func<T, U>> expression)
         {
-            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_command.TypeCache), null, CancellationToken.None);
+            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_session.TypeCache), null, CancellationToken.None);
         }
 
         public Task UnlinkEntryAsync<U>(Expression<Func<T, U>> expression, CancellationToken cancellationToken)
         {
-            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_command.TypeCache), null, cancellationToken);
+            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_session.TypeCache), null, cancellationToken);
         }
 
         public Task UnlinkEntryAsync(ODataExpression expression)
@@ -316,7 +316,7 @@ namespace Simple.OData.Client
 
         public Task UnlinkEntryAsync<U>(U linkedEntryKey, string linkName, CancellationToken cancellationToken)
         {
-            return _client.UnlinkEntryAsync(_command, linkName ?? typeof(U).Name, linkedEntryKey != null ? linkedEntryKey.ToDictionary(_command.TypeCache) : null, cancellationToken);
+            return _client.UnlinkEntryAsync(_command, linkName ?? typeof(U).Name, linkedEntryKey != null ? linkedEntryKey.ToDictionary(_session.TypeCache) : null, cancellationToken);
         }
 
         public Task UnlinkEntryAsync<U>(Expression<Func<T, U>> expression, U linkedEntryKey)
@@ -326,7 +326,7 @@ namespace Simple.OData.Client
 
         public Task UnlinkEntryAsync<U>(Expression<Func<T, U>> expression, U linkedEntryKey, CancellationToken cancellationToken)
         {
-            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_command.TypeCache), linkedEntryKey != null ? linkedEntryKey.ToDictionary(_command.TypeCache) : null, cancellationToken);
+            return _client.UnlinkEntryAsync(_command, expression.ExtractColumnName(_session.TypeCache), linkedEntryKey != null ? linkedEntryKey.ToDictionary(_session.TypeCache) : null, cancellationToken);
         }
 
         public Task UnlinkEntryAsync(ODataExpression expression, IDictionary<string, object> linkedEntryKey)
@@ -341,12 +341,12 @@ namespace Simple.OData.Client
 
         public Task UnlinkEntryAsync(ODataExpression expression, ODataEntry linkedEntryKey)
         {
-            return _client.UnlinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey?.ToDictionary(_command.TypeCache), CancellationToken.None);
+            return _client.UnlinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey?.ToDictionary(_session.TypeCache), CancellationToken.None);
         }
 
         public Task UnlinkEntryAsync(ODataExpression expression, ODataEntry linkedEntryKey, CancellationToken cancellationToken)
         {
-            return _client.UnlinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey?.ToDictionary(_command.TypeCache), cancellationToken);
+            return _client.UnlinkEntryAsync(_command, expression.AsString(_session), linkedEntryKey?.ToDictionary(_session.TypeCache), cancellationToken);
         }
     }
 }

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -136,7 +136,7 @@ namespace Simple.OData.Client
 
         public async Task<T> UpdateEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
-            if (_command.HasFilter)
+            if (_command.Details.HasFilter)
             {
                 var result = await UpdateEntriesAsync(resultRequired, cancellationToken).ConfigureAwait(false);
                 return resultRequired 
@@ -188,7 +188,7 @@ namespace Simple.OData.Client
 
         public Task DeleteEntryAsync(CancellationToken cancellationToken)
         {
-            if (_command.HasFilter)
+            if (_command.Details.HasFilter)
                 return DeleteEntriesAsync(cancellationToken);
             else
                 return _client.DeleteEntryAsync(_command, cancellationToken);

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -43,7 +43,7 @@ namespace Simple.OData.Client
 
         public async Task<IEnumerable<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
-            var commandText = await _command.WithCount().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await _command.WithCount().Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -43,7 +43,8 @@ namespace Simple.OData.Client
 
         public async Task<IEnumerable<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
-            var commandText = await _command.WithCount().Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            await _session.ResolveAdapterAsync(cancellationToken);
+            var commandText = await _command.WithCount().Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
@@ -128,7 +128,7 @@ namespace Simple.OData.Client
 
         public IRequestBuilder<T> BuildRequestFor()
         {
-            return new RequestBuilder<T>(this.Command.Resolve(_session), _session, _client.BatchWriter);
+            return new RequestBuilder<T>(this.Command, _session, _client.BatchWriter);
         }
 
 #pragma warning restore 1591

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
@@ -128,7 +128,7 @@ namespace Simple.OData.Client
 
         public IRequestBuilder<T> BuildRequestFor()
         {
-            return new RequestBuilder<T>(this.Command.Resolve(), _session, _client.BatchWriter);
+            return new RequestBuilder<T>(this.Command.Resolve(_session), _session, _client.BatchWriter);
         }
 
 #pragma warning restore 1591

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
@@ -128,7 +128,7 @@ namespace Simple.OData.Client
 
         public IRequestBuilder<T> BuildRequestFor()
         {
-            return new RequestBuilder<T>(this.Command, _session, _client.BatchWriter);
+            return new RequestBuilder<T>(this.Command.Resolve(), _session, _client.BatchWriter);
         }
 
 #pragma warning restore 1591

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
@@ -29,7 +29,7 @@ namespace Simple.OData.Client
 
         public IBoundClient<T> For(string collectionName = null)
         {
-            this.Command.For(collectionName ?? Command.TypeCache.GetMappedName(typeof(T)));
+            this.Command.For(collectionName ?? _session.TypeCache.GetMappedName(typeof(T)));
             return this;
         }
 

--- a/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/BoundClient.cs
@@ -122,9 +122,9 @@ namespace Simple.OData.Client
             return CreateClientForODataEntry();
         }
 
-        public bool FilterIsKey => this.Command.FilterIsKey;
+        public bool FilterIsKey => this.Command.Details.FilterIsKey;
 
-        public IDictionary<string, object> FilterAsKey => this.Command.FilterAsKey;
+        public IDictionary<string, object> FilterAsKey => this.Command.Details.FilterAsKey;
 
         public IRequestBuilder<T> BuildRequestFor()
         {

--- a/src/Simple.OData.Client.Core/Fluent/CommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/CommandDetails.cs
@@ -84,5 +84,19 @@ namespace Simple.OData.Client
             this.QueryOptionsExpression = details.QueryOptionsExpression;
             this.BatchEntries = details.BatchEntries;
         }
+
+        public bool HasKey => this.KeyValues != null && this.KeyValues.Count > 0 || this.NamedKeyValues != null && this.NamedKeyValues.Count > 0;
+
+        public bool HasFilter => !string.IsNullOrEmpty(this.Filter) || !ReferenceEquals(this.FilterExpression, null);
+
+        public bool HasSearch => !string.IsNullOrEmpty(this.Search);
+
+        public bool HasFunction => !string.IsNullOrEmpty(this.FunctionName);
+
+        public bool HasAction => !string.IsNullOrEmpty(this.ActionName);
+
+        public bool FilterIsKey => this.NamedKeyValues != null;
+
+        public IDictionary<string, object> FilterAsKey => this.NamedKeyValues;
     }
 }

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -628,7 +628,7 @@ namespace Simple.OData.Client
         /// <returns>The command text.</returns>
         public Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
         {
-            return this.Command.GetCommandTextAsync(cancellationToken);
+            return this.Command.Resolve().GetCommandTextAsync(cancellationToken);
         }
 
 #pragma warning disable 1591

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -52,7 +52,7 @@ namespace Simple.OData.Client
 
         protected FluentCommand CreateCommand()
         {
-            return new FluentCommand(this.Session, _parentCommand, _client.BatchEntries);
+            return new FluentCommand(_parentCommand, _client.BatchEntries);
         }
 
         internal Session Session => _session;
@@ -61,7 +61,7 @@ namespace Simple.OData.Client
 
         public FT WithProperties(Expression<Func<T, IDictionary<string, object>>> expression)
         {
-            this.Command.WithProperties(expression.ExtractColumnName(Command.TypeCache));
+            this.Command.WithProperties(expression.ExtractColumnName(_session.TypeCache));
             return this as FT;
         }
 
@@ -85,7 +85,7 @@ namespace Simple.OData.Client
 
         public FT WithMedia(Expression<Func<T, object>> expression)
         {
-            this.Command.WithMedia(expression.ExtractColumnNames(Command.TypeCache));
+            this.Command.WithMedia(expression.ExtractColumnNames(_session.TypeCache));
             return this as FT;
         }
 
@@ -109,7 +109,7 @@ namespace Simple.OData.Client
 
         public FT Key(T entryKey)
         {
-            this.Command.Key(entryKey.ToDictionary(Command.TypeCache));
+            this.Command.Key(entryKey.ToDictionary(_session.TypeCache));
             return this as FT;
         }
 
@@ -211,13 +211,13 @@ namespace Simple.OData.Client
 
         public FT Expand(Expression<Func<T, object>> expression)
         {
-            this.Command.Expand(expression.ExtractColumnNames(Command.TypeCache));
+            this.Command.Expand(expression.ExtractColumnNames(_session.TypeCache));
             return this as FT;
         }
 
         public FT Expand(ODataExpandOptions expandOptions, Expression<Func<T, object>> expression)
         {
-            this.Command.Expand(expandOptions, expression.ExtractColumnNames(Command.TypeCache));
+            this.Command.Expand(expandOptions, expression.ExtractColumnNames(_session.TypeCache));
             return this as FT;
         }
 
@@ -241,7 +241,7 @@ namespace Simple.OData.Client
 
         public FT Select(Expression<Func<T, object>> expression)
         {
-            this.Command.Select(expression.ExtractColumnNames(Command.TypeCache));
+            this.Command.Select(expression.ExtractColumnNames(_session.TypeCache));
             return this as FT;
         }
 
@@ -265,7 +265,7 @@ namespace Simple.OData.Client
 
         public FT OrderBy(Expression<Func<T, object>> expression)
         {
-            this.Command.OrderBy(expression.ExtractColumnNames(Command.TypeCache).Select(x => new KeyValuePair<string, bool>(x, false)));
+            this.Command.OrderBy(expression.ExtractColumnNames(_session.TypeCache).Select(x => new KeyValuePair<string, bool>(x, false)));
             return this as FT;
         }
 
@@ -295,7 +295,7 @@ namespace Simple.OData.Client
 
         public FT OrderByDescending(Expression<Func<T, object>> expression)
         {
-            this.Command.OrderBy(expression.ExtractColumnNames(Command.TypeCache).Select(x => new KeyValuePair<string, bool>(x, true)));
+            this.Command.OrderBy(expression.ExtractColumnNames(_session.TypeCache).Select(x => new KeyValuePair<string, bool>(x, true)));
             return this as FT;
         }
 
@@ -307,7 +307,7 @@ namespace Simple.OData.Client
 
         public FT ThenByDescending(Expression<Func<T, object>> expression)
         {
-            this.Command.ThenByDescending(expression.ExtractColumnNames(Command.TypeCache).ToArray());
+            this.Command.ThenByDescending(expression.ExtractColumnNames(_session.TypeCache).ToArray());
             return this as FT;
         }
 
@@ -355,7 +355,7 @@ namespace Simple.OData.Client
 
         public IMediaClient Media(Expression<Func<T, object>> expression)
         {
-            this.Command.Media(expression.ExtractColumnName(Command.TypeCache));
+            this.Command.Media(expression.ExtractColumnName(_session.TypeCache));
             return new MediaClient(_client, _session, this.Command, _dynamicResults);
         }
 
@@ -409,7 +409,7 @@ namespace Simple.OData.Client
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, U>> expression)
             where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.
@@ -419,7 +419,7 @@ namespace Simple.OData.Client
         /// <returns>Self.</returns>
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, IEnumerable<U>>> expression) where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.
@@ -429,7 +429,7 @@ namespace Simple.OData.Client
         /// <returns>Self.</returns>
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, IList<U>>> expression) where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.
@@ -439,7 +439,7 @@ namespace Simple.OData.Client
         /// <returns>Self.</returns>
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, ISet<U>>> expression) where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.
@@ -449,7 +449,7 @@ namespace Simple.OData.Client
         /// <returns>Self.</returns>
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, HashSet<U>>> expression) where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.
@@ -459,7 +459,7 @@ namespace Simple.OData.Client
         /// <returns>Self.</returns>
         public IBoundClient<U> NavigateTo<U>(Expression<Func<T, U[]>> expression) where U : class
         {
-            return this.Link<U>(this.Command, expression.ExtractColumnName(Command.TypeCache));
+            return this.Link<U>(this.Command, expression.ExtractColumnName(_session.TypeCache));
         }
         /// <summary>
         /// Navigates to the linked entity.

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -628,7 +628,7 @@ namespace Simple.OData.Client
         /// <returns>The command text.</returns>
         public Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
         {
-            return this.Command.Resolve().GetCommandTextAsync(cancellationToken);
+            return this.Command.Resolve(_session).GetCommandTextAsync(cancellationToken);
         }
 
 #pragma warning disable 1591

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -626,9 +626,12 @@ namespace Simple.OData.Client
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The command text.</returns>
-        public Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
+        public async Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
         {
-            return this.Command.Resolve(_session).GetCommandTextAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
+            return this.Command.Resolve(_session).Format();
         }
 
 #pragma warning disable 1591

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -38,9 +38,9 @@ namespace Simple.OData.Client
         internal ITypeCache TypeCache => Details.Session.TypeCache;
 
 
-        internal ResolvedCommand Resolve()
+        internal ResolvedCommand Resolve(ISession session)
         {
-            return new ResolvedCommand(this, Details.Session);
+            return new ResolvedCommand(this, session as Session);
         }
 
         public string DynamicPropertiesContainerName => Details.DynamicPropertiesContainerName;

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -18,34 +18,32 @@ namespace Simple.OData.Client
 
     public partial class FluentCommand
     {
-        private readonly CommandDetails _details;
-
         internal static readonly string ResultLiteral = "__result";
         internal static readonly string AnnotationsLiteral = "__annotations";
         internal static readonly string MediaEntityLiteral = "__entity";
 
         internal FluentCommand(Session session, FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
-            _details = new CommandDetails(session, parent, batchEntries);
+            Details = new CommandDetails(session, parent, batchEntries);
         }
 
         internal FluentCommand(FluentCommand ancestor)
         {
-            _details = new CommandDetails(ancestor._details);
+            Details = new CommandDetails(ancestor.Details);
         }
 
-        private bool IsBatchResponse => _details.Session == null;
+        internal CommandDetails Details { get; private set; }
+        private bool IsBatchResponse => Details.Session == null;
 
-        internal ITypeCache TypeCache => _details.Session.TypeCache;
+        internal ITypeCache TypeCache => Details.Session.TypeCache;
 
-        internal CommandDetails Details => _details;
 
         internal ResolvedCommand Resolve()
         {
-            return new ResolvedCommand(this, _details.Session);
+            return new ResolvedCommand(this, Details.Session);
         }
 
-        public string DynamicPropertiesContainerName => _details.DynamicPropertiesContainerName;
+        public string DynamicPropertiesContainerName => Details.DynamicPropertiesContainerName;
 
         public FluentCommand For(string collectionName)
         {
@@ -54,12 +52,12 @@ namespace Simple.OData.Client
             var items = collectionName.Split('/');
             if (items.Count() > 1)
             {
-                _details.CollectionName = items[0];
-                _details.DerivedCollectionName = items[1];
+                Details.CollectionName = items[0];
+                Details.DerivedCollectionName = items[1];
             }
             else
             {
-                _details.CollectionName = collectionName;
+                Details.CollectionName = collectionName;
             }
             return this;
         }
@@ -68,7 +66,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.DynamicPropertiesContainerName = propertyName;
+            Details.DynamicPropertiesContainerName = propertyName;
             return this;
         }
 
@@ -76,7 +74,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.MediaProperties = properties;
+            Details.MediaProperties = properties;
             return this;
         }
 
@@ -84,7 +82,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.MediaProperties = SplitItems(properties).ToList();
+            Details.MediaProperties = SplitItems(properties).ToList();
             return this;
         }
 
@@ -97,7 +95,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.CollectionExpression = expression;
+            Details.CollectionExpression = expression;
             return this;
         }
 
@@ -105,7 +103,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.DerivedCollectionName = derivedCollectionName;
+            Details.DerivedCollectionName = derivedCollectionName;
             return this;
         }
 
@@ -113,7 +111,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.DerivedCollectionExpression = expression;
+            Details.DerivedCollectionExpression = expression;
             return this;
         }
 
@@ -121,7 +119,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.LinkName = linkName;
+            Details.LinkName = linkName;
             return this;
         }
 
@@ -129,7 +127,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.LinkExpression = expression;
+            Details.LinkExpression = expression;
             return this;
         }
 
@@ -151,9 +149,9 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.KeyValues = key.ToList();
-            _details.NamedKeyValues = null;
-            _details.IsAlternateKey = false;
+            Details.KeyValues = key.ToList();
+            Details.NamedKeyValues = null;
+            Details.IsAlternateKey = false;
             return this;
         }
 
@@ -161,9 +159,9 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.KeyValues = null;
-            _details.NamedKeyValues = key;
-            _details.IsAlternateKey = false;
+            Details.KeyValues = null;
+            Details.NamedKeyValues = key;
+            Details.IsAlternateKey = false;
             return this;
         }
 
@@ -171,10 +169,10 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            if (string.IsNullOrEmpty(_details.Filter))
-                _details.Filter = filter;
+            if (string.IsNullOrEmpty(Details.Filter))
+                Details.Filter = filter;
             else
-                _details.Filter = $"({_details.Filter}) and ({filter})";
+                Details.Filter = $"({Details.Filter}) and ({filter})";
             return this;
         }
 
@@ -182,10 +180,10 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            if (ReferenceEquals(_details.FilterExpression, null))
-                _details.FilterExpression = expression;
+            if (ReferenceEquals(Details.FilterExpression, null))
+                Details.FilterExpression = expression;
             else
-                _details.FilterExpression = _details.FilterExpression && expression;
+                Details.FilterExpression = Details.FilterExpression && expression;
             return this;
         }
 
@@ -193,7 +191,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.Search = search;
+            Details.Search = search;
             return this;
         }
 
@@ -201,7 +199,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.SkipCount = count;
+            Details.SkipCount = count;
             return this;
         }
 
@@ -211,7 +209,7 @@ namespace Simple.OData.Client
 
             if (!HasKey || HasFunction)
             {
-                _details.TopCount = count;
+                Details.TopCount = count;
             }
             else if (count != 1)
             {
@@ -224,7 +222,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ExpandAssociations.AddRange(new[] { new KeyValuePair<string, ODataExpandOptions>("*", ODataExpandOptions.ByValue()) });
+            Details.ExpandAssociations.AddRange(new[] { new KeyValuePair<string, ODataExpandOptions>("*", ODataExpandOptions.ByValue()) });
             return this;
         }
 
@@ -232,7 +230,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
+            Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
             return this;
         }
 
@@ -240,7 +238,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
+            Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
             return this;
         }
 
@@ -248,7 +246,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
+            Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
             return this;
         }
 
@@ -256,7 +254,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
+            Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
             return this;
         }
 
@@ -274,7 +272,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.SelectColumns.AddRange(SplitItems(columns).ToList());
+            Details.SelectColumns.AddRange(SplitItems(columns).ToList());
             return this;
         }
 
@@ -282,7 +280,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.SelectColumns.AddRange(SplitItems(columns).ToList());
+            Details.SelectColumns.AddRange(SplitItems(columns).ToList());
             return this;
         }
 
@@ -295,7 +293,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.OrderbyColumns.AddRange(SplitItems(columns));
+            Details.OrderbyColumns.AddRange(SplitItems(columns));
             return this;
         }
 
@@ -313,7 +311,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, false)));
+            Details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, false)));
             return this;
         }
 
@@ -336,7 +334,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, true)));
+            Details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, true)));
             return this;
         }
 
@@ -349,10 +347,10 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            if (_details.QueryOptions == null)
-                _details.QueryOptions = queryOptions;
+            if (Details.QueryOptions == null)
+                Details.QueryOptions = queryOptions;
             else
-                _details.QueryOptions = $"{_details.QueryOptions}&{queryOptions}";
+                Details.QueryOptions = $"{Details.QueryOptions}&{queryOptions}";
             return this;
         }
 
@@ -360,7 +358,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.QueryOptionsKeyValues = queryOptions;
+            Details.QueryOptionsKeyValues = queryOptions;
             return this;
         }
 
@@ -368,10 +366,10 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            if (ReferenceEquals(_details.QueryOptionsExpression, null))
-                _details.QueryOptionsExpression = expression;
+            if (ReferenceEquals(Details.QueryOptionsExpression, null))
+                Details.QueryOptionsExpression = expression;
             else
-                _details.QueryOptionsExpression = _details.QueryOptionsExpression && expression;
+                Details.QueryOptionsExpression = Details.QueryOptionsExpression && expression;
             return this;
         }
 
@@ -384,7 +382,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.MediaName = streamName;
+            Details.MediaName = streamName;
             return this;
         }
 
@@ -397,7 +395,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ComputeCount = true;
+            Details.ComputeCount = true;
             return this;
         }
 
@@ -405,8 +403,8 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.EntryData = TypeCache.ToDictionary(value);
-            _details.BatchEntries?.GetOrAdd(value, _details.EntryData);
+            Details.EntryData = TypeCache.ToDictionary(value);
+            Details.BatchEntries?.GetOrAdd(value, Details.EntryData);
 
             return this;
         }
@@ -415,7 +413,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.EntryData = value;
+            Details.EntryData = value;
             return this;
         }
 
@@ -423,8 +421,8 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.EntryData = value.Select(x => new KeyValuePair<string, object>(x.Reference, x.Value)).ToIDictionary();
-            _details.BatchEntries?.GetOrAdd(value, _details.EntryData);
+            Details.EntryData = value.Select(x => new KeyValuePair<string, object>(x.Reference, x.Value)).ToIDictionary();
+            Details.BatchEntries?.GetOrAdd(value, Details.EntryData);
 
             return this;
         }
@@ -433,7 +431,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.FunctionName = functionName;
+            Details.FunctionName = functionName;
             return this;
         }
 
@@ -441,51 +439,51 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            _details.ActionName = actionName;
+            Details.ActionName = actionName;
             return this;
         }
 
-        public bool FilterIsKey => _details.NamedKeyValues != null;
+        public bool FilterIsKey => Details.NamedKeyValues != null;
 
-        public IDictionary<string, object> FilterAsKey => _details.NamedKeyValues;
+        public IDictionary<string, object> FilterAsKey => Details.NamedKeyValues;
 
         public FluentCommand WithCount()
         {
             if (IsBatchResponse) return this;
 
-            _details.IncludeCount = true;
+            Details.IncludeCount = true;
             return this;
         }
 
-        internal bool HasKey => _details.KeyValues != null && _details.KeyValues.Count > 0 || _details.NamedKeyValues != null && _details.NamedKeyValues.Count > 0;
+        internal bool HasKey => Details.KeyValues != null && Details.KeyValues.Count > 0 || Details.NamedKeyValues != null && Details.NamedKeyValues.Count > 0;
 
-        internal bool HasFilter => !string.IsNullOrEmpty(_details.Filter) || !ReferenceEquals(_details.FilterExpression, null);
+        internal bool HasFilter => !string.IsNullOrEmpty(Details.Filter) || !ReferenceEquals(Details.FilterExpression, null);
 
-        internal bool HasSearch => !string.IsNullOrEmpty(_details.Search);
+        internal bool HasSearch => !string.IsNullOrEmpty(Details.Search);
 
-        public bool HasFunction => !string.IsNullOrEmpty(_details.FunctionName);
+        public bool HasFunction => !string.IsNullOrEmpty(Details.FunctionName);
 
-        public bool HasAction => !string.IsNullOrEmpty(_details.ActionName);
+        public bool HasAction => !string.IsNullOrEmpty(Details.ActionName);
 
-        internal IDictionary<string, object> KeyValues => !HasKey ? null : _details.NamedKeyValues;
+        internal IDictionary<string, object> KeyValues => !HasKey ? null : Details.NamedKeyValues;
 
         internal IDictionary<string, object> CommandData
         {
             get
             {
-                if (_details.EntryData == null)
+                if (Details.EntryData == null)
                     return new Dictionary<string, object>();
-                if (string.IsNullOrEmpty(_details.DynamicPropertiesContainerName))
-                    return _details.EntryData;
+                if (string.IsNullOrEmpty(Details.DynamicPropertiesContainerName))
+                    return Details.EntryData;
 
                 var entryData = new Dictionary<string, object>();
-                foreach (var key in _details.EntryData.Keys.Where(x =>
-                    !string.Equals(x, _details.DynamicPropertiesContainerName, StringComparison.OrdinalIgnoreCase)))
+                foreach (var key in Details.EntryData.Keys.Where(x =>
+                    !string.Equals(x, Details.DynamicPropertiesContainerName, StringComparison.OrdinalIgnoreCase)))
                 {
-                    entryData.Add(key, _details.EntryData[key]);
+                    entryData.Add(key, Details.EntryData[key]);
                 }
 
-                if (_details.EntryData.TryGetValue(_details.DynamicPropertiesContainerName, out var dynamicProperties) && dynamicProperties != null)
+                if (Details.EntryData.TryGetValue(Details.DynamicPropertiesContainerName, out var dynamicProperties) && dynamicProperties != null)
                 {
                     if (dynamicProperties is IDictionary<string, object> kv)
                     {
@@ -496,7 +494,7 @@ namespace Simple.OData.Client
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Property {_details.DynamicPropertiesContainerName} must implement IDictionary<string,object> interface");
+                        throw new InvalidOperationException($"Property {Details.DynamicPropertiesContainerName} must implement IDictionary<string,object> interface");
                     }
                 }
 
@@ -504,11 +502,11 @@ namespace Simple.OData.Client
             }
         }
 
-        internal IList<string> SelectedColumns => _details.SelectColumns;
+        internal IList<string> SelectedColumns => Details.SelectColumns;
 
-        internal string FunctionName => _details.FunctionName;
+        internal string FunctionName => Details.FunctionName;
 
-        internal string ActionName => _details.ActionName;
+        internal string ActionName => Details.ActionName;
 
         private IEnumerable<string> SplitItems(IEnumerable<string> columns)
         {

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -207,7 +207,7 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse) return this;
 
-            if (!HasKey || HasFunction)
+            if (!Details.HasKey || Details.HasFunction)
             {
                 Details.TopCount = count;
             }
@@ -443,10 +443,6 @@ namespace Simple.OData.Client
             return this;
         }
 
-        public bool FilterIsKey => Details.NamedKeyValues != null;
-
-        public IDictionary<string, object> FilterAsKey => Details.NamedKeyValues;
-
         public FluentCommand WithCount()
         {
             if (IsBatchResponse) return this;
@@ -455,58 +451,7 @@ namespace Simple.OData.Client
             return this;
         }
 
-        internal bool HasKey => Details.KeyValues != null && Details.KeyValues.Count > 0 || Details.NamedKeyValues != null && Details.NamedKeyValues.Count > 0;
-
-        internal bool HasFilter => !string.IsNullOrEmpty(Details.Filter) || !ReferenceEquals(Details.FilterExpression, null);
-
-        internal bool HasSearch => !string.IsNullOrEmpty(Details.Search);
-
-        public bool HasFunction => !string.IsNullOrEmpty(Details.FunctionName);
-
-        public bool HasAction => !string.IsNullOrEmpty(Details.ActionName);
-
-        internal IDictionary<string, object> KeyValues => !HasKey ? null : Details.NamedKeyValues;
-
-        internal IDictionary<string, object> CommandData
-        {
-            get
-            {
-                if (Details.EntryData == null)
-                    return new Dictionary<string, object>();
-                if (string.IsNullOrEmpty(Details.DynamicPropertiesContainerName))
-                    return Details.EntryData;
-
-                var entryData = new Dictionary<string, object>();
-                foreach (var key in Details.EntryData.Keys.Where(x =>
-                    !string.Equals(x, Details.DynamicPropertiesContainerName, StringComparison.OrdinalIgnoreCase)))
-                {
-                    entryData.Add(key, Details.EntryData[key]);
-                }
-
-                if (Details.EntryData.TryGetValue(Details.DynamicPropertiesContainerName, out var dynamicProperties) && dynamicProperties != null)
-                {
-                    if (dynamicProperties is IDictionary<string, object> kv)
-                    {
-                        foreach (var key in kv.Keys)
-                        {
-                            entryData.Add(key, kv[key]);
-                        }
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Property {Details.DynamicPropertiesContainerName} must implement IDictionary<string,object> interface");
-                    }
-                }
-
-                return entryData;
-            }
-        }
-
         internal IList<string> SelectedColumns => Details.SelectColumns;
-
-        internal string FunctionName => Details.FunctionName;
-
-        internal string ActionName => Details.ActionName;
 
         private IEnumerable<string> SplitItems(IEnumerable<string> columns)
         {

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -25,13 +25,13 @@ namespace Simple.OData.Client
         internal FluentCommand(Session session, FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
             Session = session;
-            Details = new FluentCommandDetails(parent, batchEntries);
+            Details = new FluentCommandDetails(parent?.Details, batchEntries);
         }
 
-        internal FluentCommand(FluentCommand command)
+        internal FluentCommand(ISession session, FluentCommandDetails details)
         {
-            Session = command.Session;
-            Details = new FluentCommandDetails(command.Details);
+            Session = session as Session;
+            Details = new FluentCommandDetails(details);
         }
 
         internal FluentCommand(ResolvedCommand command)

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -34,6 +34,12 @@ namespace Simple.OData.Client
             Details = new FluentCommandDetails(command.Details);
         }
 
+        internal FluentCommand(ResolvedCommand command)
+        {
+            Session = command.Session;
+            Details = new FluentCommandDetails(command.Details);
+        }
+
         internal Session Session { get; private set; }
 
         internal FluentCommandDetails Details { get; private set; }

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -20,29 +20,22 @@ namespace Simple.OData.Client
         internal static readonly string AnnotationsLiteral = "__annotations";
         internal static readonly string MediaEntityLiteral = "__entity";
 
-        internal FluentCommand(Session session, FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
+        internal FluentCommand(FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
-            Session = session;
             Details = new FluentCommandDetails(parent?.Details, batchEntries);
         }
 
-        internal FluentCommand(ISession session, FluentCommandDetails details)
+        internal FluentCommand(FluentCommandDetails details)
         {
-            Session = session as Session;
             Details = new FluentCommandDetails(details);
         }
 
         internal FluentCommand(ResolvedCommand command)
         {
-            Session = command.Session;
             Details = new FluentCommandDetails(command.Details);
         }
 
-        internal ISession Session { get; private set; }
-
         internal FluentCommandDetails Details { get; private set; }
-
-        internal ITypeCache TypeCache => Session.TypeCache;
 
 
         internal ResolvedCommand Resolve(ISession session)
@@ -122,14 +115,7 @@ namespace Simple.OData.Client
 
         public FluentCommand Key(params object[] key)
         {
-            if (key != null && key.Length == 1 && TypeCache.IsAnonymousType(key.First().GetType()))
-            {
-                return Key(TypeCache.ToDictionary(key.First()));
-            }
-            else
-            {
-                return Key(key.ToList());
-            }
+            return Key(key.ToList());
         }
 
         public FluentCommand Key(IEnumerable<object> key)
@@ -344,8 +330,7 @@ namespace Simple.OData.Client
 
         public FluentCommand Set(object value)
         {
-            Details.EntryData = TypeCache.ToDictionary(value);
-            Details.BatchEntries?.GetOrAdd(value, Details.EntryData);
+            Details.EntryValue = value;
             return this;
         }
 

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -24,17 +24,21 @@ namespace Simple.OData.Client
 
         internal FluentCommand(Session session, FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
-            Details = new CommandDetails(session, parent, batchEntries);
+            Session = session;
+            Details = new FluentCommandDetails(parent, batchEntries);
         }
 
-        internal FluentCommand(FluentCommand ancestor)
+        internal FluentCommand(FluentCommand command)
         {
-            Details = new CommandDetails(ancestor.Details);
+            Session = command.Session;
+            Details = new FluentCommandDetails(command.Details);
         }
 
-        internal CommandDetails Details { get; private set; }
+        internal Session Session { get; private set; }
 
-        internal ITypeCache TypeCache => Details.Session.TypeCache;
+        internal FluentCommandDetails Details { get; private set; }
+
+        internal ITypeCache TypeCache => Session.TypeCache;
 
 
         internal ResolvedCommand Resolve(ISession session)

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -33,7 +33,6 @@ namespace Simple.OData.Client
         }
 
         internal CommandDetails Details { get; private set; }
-        private bool IsBatchResponse => Details.Session == null;
 
         internal ITypeCache TypeCache => Details.Session.TypeCache;
 
@@ -47,8 +46,6 @@ namespace Simple.OData.Client
 
         public FluentCommand For(string collectionName)
         {
-            if (IsBatchResponse) return this;
-
             var items = collectionName.Split('/');
             if (items.Count() > 1)
             {
@@ -64,24 +61,18 @@ namespace Simple.OData.Client
 
         public FluentCommand WithProperties(string propertyName)
         {
-            if (IsBatchResponse) return this;
-
             Details.DynamicPropertiesContainerName = propertyName;
             return this;
         }
 
         public FluentCommand WithMedia(IEnumerable<string> properties)
         {
-            if (IsBatchResponse) return this;
-
             Details.MediaProperties = properties;
             return this;
         }
 
         public FluentCommand WithMedia(params string[] properties)
         {
-            if (IsBatchResponse) return this;
-
             Details.MediaProperties = SplitItems(properties).ToList();
             return this;
         }
@@ -93,48 +84,36 @@ namespace Simple.OData.Client
 
         public FluentCommand For(ODataExpression expression)
         {
-            if (IsBatchResponse) return this;
-
             Details.CollectionExpression = expression;
             return this;
         }
 
         public FluentCommand As(string derivedCollectionName)
         {
-            if (IsBatchResponse) return this;
-
             Details.DerivedCollectionName = derivedCollectionName;
             return this;
         }
 
         public FluentCommand As(ODataExpression expression)
         {
-            if (IsBatchResponse) return this;
-
             Details.DerivedCollectionExpression = expression;
             return this;
         }
 
         public FluentCommand Link(string linkName)
         {
-            if (IsBatchResponse) return this;
-
             Details.LinkName = linkName;
             return this;
         }
 
         public FluentCommand Link(ODataExpression expression)
         {
-            if (IsBatchResponse) return this;
-
             Details.LinkExpression = expression;
             return this;
         }
 
         public FluentCommand Key(params object[] key)
         {
-            if (IsBatchResponse) return this;
-
             if (key != null && key.Length == 1 && TypeCache.IsAnonymousType(key.First().GetType()))
             {
                 return Key(TypeCache.ToDictionary(key.First()));
@@ -147,8 +126,6 @@ namespace Simple.OData.Client
 
         public FluentCommand Key(IEnumerable<object> key)
         {
-            if (IsBatchResponse) return this;
-
             Details.KeyValues = key.ToList();
             Details.NamedKeyValues = null;
             Details.IsAlternateKey = false;
@@ -157,8 +134,6 @@ namespace Simple.OData.Client
 
         public FluentCommand Key(IDictionary<string, object> key)
         {
-            if (IsBatchResponse) return this;
-
             Details.KeyValues = null;
             Details.NamedKeyValues = key;
             Details.IsAlternateKey = false;
@@ -167,8 +142,6 @@ namespace Simple.OData.Client
 
         public FluentCommand Filter(string filter)
         {
-            if (IsBatchResponse) return this;
-
             if (string.IsNullOrEmpty(Details.Filter))
                 Details.Filter = filter;
             else
@@ -178,8 +151,6 @@ namespace Simple.OData.Client
 
         public FluentCommand Filter(ODataExpression expression)
         {
-            if (IsBatchResponse) return this;
-
             if (ReferenceEquals(Details.FilterExpression, null))
                 Details.FilterExpression = expression;
             else
@@ -189,24 +160,18 @@ namespace Simple.OData.Client
 
         public FluentCommand Search(string search)
         {
-            if (IsBatchResponse) return this;
-
             Details.Search = search;
             return this;
         }
 
         public FluentCommand Skip(long count)
         {
-            if (IsBatchResponse) return this;
-
             Details.SkipCount = count;
             return this;
         }
 
         public FluentCommand Top(long count)
         {
-            if (IsBatchResponse) return this;
-
             if (!Details.HasKey || Details.HasFunction)
             {
                 Details.TopCount = count;
@@ -220,40 +185,30 @@ namespace Simple.OData.Client
 
         public FluentCommand Expand(ODataExpandOptions expandOptions)
         {
-            if (IsBatchResponse) return this;
-
             Details.ExpandAssociations.AddRange(new[] { new KeyValuePair<string, ODataExpandOptions>("*", ODataExpandOptions.ByValue()) });
             return this;
         }
 
         public FluentCommand Expand(IEnumerable<string> associations)
         {
-            if (IsBatchResponse) return this;
-
             Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
             return this;
         }
 
         public FluentCommand Expand(ODataExpandOptions expandOptions, IEnumerable<string> associations)
         {
-            if (IsBatchResponse) return this;
-
             Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
             return this;
         }
 
         public FluentCommand Expand(params string[] associations)
         {
-            if (IsBatchResponse) return this;
-
             Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, ODataExpandOptions.ByValue())));
             return this;
         }
 
         public FluentCommand Expand(ODataExpandOptions expandOptions, params string[] associations)
         {
-            if (IsBatchResponse) return this;
-
             Details.ExpandAssociations.AddRange(SplitItems(associations).Select(x => new KeyValuePair<string, ODataExpandOptions>(x, expandOptions)));
             return this;
         }
@@ -270,16 +225,12 @@ namespace Simple.OData.Client
 
         public FluentCommand Select(IEnumerable<string> columns)
         {
-            if (IsBatchResponse) return this;
-
             Details.SelectColumns.AddRange(SplitItems(columns).ToList());
             return this;
         }
 
         public FluentCommand Select(params string[] columns)
         {
-            if (IsBatchResponse) return this;
-
             Details.SelectColumns.AddRange(SplitItems(columns).ToList());
             return this;
         }
@@ -291,8 +242,6 @@ namespace Simple.OData.Client
 
         public FluentCommand OrderBy(IEnumerable<KeyValuePair<string, bool>> columns)
         {
-            if (IsBatchResponse) return this;
-
             Details.OrderbyColumns.AddRange(SplitItems(columns));
             return this;
         }
@@ -309,8 +258,6 @@ namespace Simple.OData.Client
 
         public FluentCommand ThenBy(params string[] columns)
         {
-            if (IsBatchResponse) return this;
-
             Details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, false)));
             return this;
         }
@@ -332,8 +279,6 @@ namespace Simple.OData.Client
 
         public FluentCommand ThenByDescending(params string[] columns)
         {
-            if (IsBatchResponse) return this;
-
             Details.OrderbyColumns.AddRange(SplitItems(columns).Select(x => new KeyValuePair<string, bool>(x, true)));
             return this;
         }
@@ -345,8 +290,6 @@ namespace Simple.OData.Client
 
         public FluentCommand QueryOptions(string queryOptions)
         {
-            if (IsBatchResponse) return this;
-
             if (Details.QueryOptions == null)
                 Details.QueryOptions = queryOptions;
             else
@@ -356,16 +299,12 @@ namespace Simple.OData.Client
 
         public FluentCommand QueryOptions(IDictionary<string, object> queryOptions)
         {
-            if (IsBatchResponse) return this;
-
             Details.QueryOptionsKeyValues = queryOptions;
             return this;
         }
 
         public FluentCommand QueryOptions(ODataExpression expression)
         {
-            if (IsBatchResponse) return this;
-
             if (ReferenceEquals(Details.QueryOptionsExpression, null))
                 Details.QueryOptionsExpression = expression;
             else
@@ -380,8 +319,6 @@ namespace Simple.OData.Client
 
         public FluentCommand Media(string streamName)
         {
-            if (IsBatchResponse) return this;
-
             Details.MediaName = streamName;
             return this;
         }
@@ -393,60 +330,44 @@ namespace Simple.OData.Client
 
         public FluentCommand Count()
         {
-            if (IsBatchResponse) return this;
-
             Details.ComputeCount = true;
             return this;
         }
 
         public FluentCommand Set(object value)
         {
-            if (IsBatchResponse) return this;
-
             Details.EntryData = TypeCache.ToDictionary(value);
             Details.BatchEntries?.GetOrAdd(value, Details.EntryData);
-
             return this;
         }
 
         public FluentCommand Set(IDictionary<string, object> value)
         {
-            if (IsBatchResponse) return this;
-
             Details.EntryData = value;
             return this;
         }
 
         public FluentCommand Set(params ODataExpression[] value)
         {
-            if (IsBatchResponse) return this;
-
             Details.EntryData = value.Select(x => new KeyValuePair<string, object>(x.Reference, x.Value)).ToIDictionary();
             Details.BatchEntries?.GetOrAdd(value, Details.EntryData);
-
             return this;
         }
 
         public FluentCommand Function(string functionName)
         {
-            if (IsBatchResponse) return this;
-
             Details.FunctionName = functionName;
             return this;
         }
 
         public FluentCommand Action(string actionName)
         {
-            if (IsBatchResponse) return this;
-
             Details.ActionName = actionName;
             return this;
         }
 
         public FluentCommand WithCount()
         {
-            if (IsBatchResponse) return this;
-
             Details.IncludeCount = true;
             return this;
         }

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Simple.OData.Client.Extensions;
 
@@ -40,7 +38,7 @@ namespace Simple.OData.Client
             Details = new FluentCommandDetails(command.Details);
         }
 
-        internal Session Session { get; private set; }
+        internal ISession Session { get; private set; }
 
         internal FluentCommandDetails Details { get; private set; }
 
@@ -49,7 +47,7 @@ namespace Simple.OData.Client
 
         internal ResolvedCommand Resolve(ISession session)
         {
-            return new ResolvedCommand(this, session as Session);
+            return new ResolvedCommand(this, session);
         }
 
         public string DynamicPropertiesContainerName => Details.DynamicPropertiesContainerName;

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 
 namespace Simple.OData.Client
 {
-    class CommandDetails
+    class FluentCommandDetails
     {
-        public Session Session { get; private set; }
         public FluentCommand Parent { get; private set; }
         public string CollectionName { get; set; }
         public ODataExpression CollectionExpression { get; set; }
@@ -37,9 +36,8 @@ namespace Simple.OData.Client
         public IEnumerable<string> MediaProperties { get; set; }
         public ConcurrentDictionary<object, IDictionary<string, object>> BatchEntries { get; set; }
 
-        public CommandDetails(Session session, FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
+        public FluentCommandDetails(FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
-            this.Session = session;
             this.Parent = parent;
             this.SkipCount = -1;
             this.TopCount = -1;
@@ -50,9 +48,8 @@ namespace Simple.OData.Client
             this.BatchEntries = batchEntries;
         }
 
-        public CommandDetails(CommandDetails details)
+        public FluentCommandDetails(FluentCommandDetails details)
         {
-            this.Session = details.Session;
             this.Parent = details.Parent;
             this.CollectionName = details.CollectionName;
             this.CollectionExpression = details.CollectionExpression;

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
@@ -16,6 +16,7 @@ namespace Simple.OData.Client
         public bool IsAlternateKey { get; set; }
         public IList<object> KeyValues { get; set; }
         public IDictionary<string, object> NamedKeyValues { get; set; }
+        public object EntryValue { get; set; }
         public IDictionary<string, object> EntryData { get; set; }
         public string Filter { get; set; }
         public ODataExpression FilterExpression { get; set; }
@@ -61,6 +62,7 @@ namespace Simple.OData.Client
             this.IsAlternateKey = details.IsAlternateKey;
             this.KeyValues = details.KeyValues;
             this.NamedKeyValues = details.NamedKeyValues;
+            this.EntryValue = details.EntryValue;
             this.EntryData = details.EntryData;
             this.Filter = details.Filter;
             this.FilterExpression = details.FilterExpression;

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
@@ -5,7 +5,7 @@ namespace Simple.OData.Client
 {
     class FluentCommandDetails
     {
-        public FluentCommand Parent { get; private set; }
+        public FluentCommandDetails Parent { get; private set; }
         public string CollectionName { get; set; }
         public ODataExpression CollectionExpression { get; set; }
         public string DerivedCollectionName { get; set; }
@@ -36,7 +36,7 @@ namespace Simple.OData.Client
         public IEnumerable<string> MediaProperties { get; set; }
         public ConcurrentDictionary<object, IDictionary<string, object>> BatchEntries { get; set; }
 
-        public FluentCommandDetails(FluentCommand parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
+        public FluentCommandDetails(FluentCommandDetails parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
             this.Parent = parent;
             this.SkipCount = -1;

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -145,7 +145,7 @@ namespace Simple.OData.Client
         {
             var entryIdent = command.Details.HasKey
                 ? await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false) 
-                : await (new FluentCommand(command.Source).Key(command.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
+                : await (new FluentCommand(command).Key(command.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -199,6 +199,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntriesAsync(bool scalarResult, CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(scalarResult, cancellationToken).ConfigureAwait(false), _session);
         }
@@ -210,6 +213,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session).WithCount(), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(false, cancellationToken).ConfigureAwait(false), _session);
         }
@@ -221,6 +227,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntryAsync(CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(false, cancellationToken), _session);
         }
@@ -242,6 +251,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> InsertEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.InsertRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false), _session);
         }
@@ -263,6 +275,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> UpdateEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.UpdateRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false), _session);
         }
@@ -274,6 +289,9 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> DeleteEntryAsync(CancellationToken cancellationToken)
         {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.DeleteRequestAsync(cancellationToken).ConfigureAwait(false), _session);
         }

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -145,7 +145,7 @@ namespace Simple.OData.Client
         {
             var entryIdent = command.HasKey
                 ? await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false) 
-                : await (new FluentCommand(command.Source).Key(command.FilterAsKey).Resolve().GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
+                : await (new FluentCommand(command.Source).Key(command.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -62,7 +62,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var collectionName = _command.QualifiedEntityCollectionName;
-            var entryKey = _command.HasKey ? _command.KeyValues : _command.FilterAsKey;
+            var entryKey = _command.Details.HasKey ? _command.KeyValues : _command.FilterAsKey;
             var entryData = _command.CommandData;
             var entryIdent = await FormatEntryKeyAsync(_command, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -103,7 +103,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var collectionName = _command.QualifiedEntityCollectionName;
-            var entryKey = _command.HasKey ? _command.KeyValues : _command.FilterAsKey;
+            var entryKey = _command.Details.HasKey ? _command.KeyValues : _command.FilterAsKey;
 
             var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -124,7 +124,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var collectionName = _command.QualifiedEntityCollectionName;
-            var entryKey = _command.HasKey ? _command.KeyValues : _command.FilterAsKey;
+            var entryKey = _command.Details.HasKey ? _command.KeyValues : _command.FilterAsKey;
 
             var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -143,7 +143,7 @@ namespace Simple.OData.Client
 
         private async Task<string> FormatEntryKeyAsync(ResolvedCommand command, CancellationToken cancellationToken)
         {
-            var entryIdent = command.HasKey
+            var entryIdent = command.Details.HasKey
                 ? await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false) 
                 : await (new FluentCommand(command.Source).Key(command.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
@@ -163,7 +163,7 @@ namespace Simple.OData.Client
 
         private void AssertHasKey(ResolvedCommand command)
         {
-            if (!command.HasKey && command.FilterAsKey == null)
+            if (!command.Details.HasKey && command.FilterAsKey == null)
                 throw new InvalidOperationException("No entry key specified.");
         }
     }

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -171,11 +171,11 @@ namespace Simple.OData.Client
     internal class RequestBuilder<T> : IRequestBuilder<T>
         where T : class
     {
-        private ResolvedCommand _command;
+        private readonly FluentCommand _command;
         private readonly Session _session;
         private readonly Lazy<IBatchWriter> _lazyBatchWriter;
 
-        public RequestBuilder(ResolvedCommand command, Session session, Lazy<IBatchWriter> batchWriter)
+        public RequestBuilder(FluentCommand command, Session session, Lazy<IBatchWriter> batchWriter)
         {
             _command = command;
             _session = session;
@@ -199,7 +199,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntriesAsync(bool scalarResult, CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command, _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(scalarResult, cancellationToken).ConfigureAwait(false), _session);
         }
 
@@ -210,7 +210,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command.WithCount(), _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session).WithCount(), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(false, cancellationToken).ConfigureAwait(false), _session);
         }
 
@@ -221,7 +221,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> FindEntryAsync(CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command, _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.GetRequestAsync(false, cancellationToken), _session);
         }
 
@@ -242,7 +242,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> InsertEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command, _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.InsertRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false), _session);
         }
 
@@ -263,7 +263,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> UpdateEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command, _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.UpdateRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false), _session);
         }
 
@@ -274,7 +274,7 @@ namespace Simple.OData.Client
 
         public async Task<IClientWithRequest<T>> DeleteEntryAsync(CancellationToken cancellationToken)
         {
-            var requestBuilder = new RequestBuilder(_command, _session, _lazyBatchWriter);
+            var requestBuilder = new RequestBuilder(_command.Resolve(_session), _session, _lazyBatchWriter);
             return new ClientWithRequest<T>(await requestBuilder.DeleteRequestAsync(cancellationToken).ConfigureAwait(false), _session);
         }
     }

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -8,12 +8,12 @@ namespace Simple.OData.Client
 {
     internal class RequestBuilder : IRequestBuilder
     {
-        private readonly FluentCommand _command;
+        private readonly ResolvedCommand _command;
         private readonly string _commandText;
         private readonly Session _session;
         private readonly Lazy<IBatchWriter> _lazyBatchWriter;
 
-        public RequestBuilder(FluentCommand command, Session session, Lazy<IBatchWriter> batchWriter)
+        public RequestBuilder(ResolvedCommand command, Session session, Lazy<IBatchWriter> batchWriter)
         {
             _command = command;
             _session = session;
@@ -141,11 +141,11 @@ namespace Simple.OData.Client
                 .CreateUnlinkRequestAsync(collectionName, linkName, entryIdent, linkIdent).ConfigureAwait(false);
         }
 
-        private async Task<string> FormatEntryKeyAsync(FluentCommand command, CancellationToken cancellationToken)
+        private async Task<string> FormatEntryKeyAsync(ResolvedCommand command, CancellationToken cancellationToken)
         {
             var entryIdent = command.HasKey
                 ? await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false) 
-                : await (new FluentCommand(command).Key(command.FilterAsKey).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
+                : await (new FluentCommand(command.Source).Key(command.FilterAsKey).Resolve().GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }
@@ -161,7 +161,7 @@ namespace Simple.OData.Client
             return entryIdent;
         }
 
-        private void AssertHasKey(FluentCommand command)
+        private void AssertHasKey(ResolvedCommand command)
         {
             if (!command.HasKey && command.FilterAsKey == null)
                 throw new InvalidOperationException("No entry key specified.");
@@ -171,11 +171,11 @@ namespace Simple.OData.Client
     internal class RequestBuilder<T> : IRequestBuilder<T>
         where T : class
     {
-        private FluentCommand _command;
+        private ResolvedCommand _command;
         private readonly Session _session;
         private readonly Lazy<IBatchWriter> _lazyBatchWriter;
 
-        public RequestBuilder(FluentCommand command, Session session, Lazy<IBatchWriter> batchWriter)
+        public RequestBuilder(ResolvedCommand command, Session session, Lazy<IBatchWriter> batchWriter)
         {
             _command = command;
             _session = session;

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -12,7 +12,7 @@ namespace Simple.OData.Client
 {
     public class ResolvedCommand
     {
-        internal ResolvedCommand(FluentCommand command, Session session)
+        internal ResolvedCommand(FluentCommand command, ISession session)
         {
             Session = session;
             Details = new FluentCommandDetails(command.Details);
@@ -25,7 +25,7 @@ namespace Simple.OData.Client
             ResolveFilter(command.Details);
         }
 
-        internal Session Session { get; private set; }
+        internal ISession Session { get; private set; }
 
         internal FluentCommandDetails Details { get; private set; }
 
@@ -162,17 +162,6 @@ namespace Simple.OData.Client
             }
         }
 
-        public Task<string> GetCommandTextAsync()
-        {
-            return GetCommandTextAsync(CancellationToken.None);
-        }
-
-        public async Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
-        {
-            await this.Session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
-            return Format();
-        }
-
         public IDictionary<string, object> FilterAsKey => Details.NamedKeyValues;
 
         public ResolvedCommand WithCount()
@@ -186,7 +175,7 @@ namespace Simple.OData.Client
             return Format();
         }
 
-        private string Format()
+        public string Format()
         {
             return this.Session.Adapter.GetCommandFormatter().FormatCommand(this);
         }

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -45,7 +45,7 @@ namespace Simple.OData.Client
                 EntityCollection entityCollection;
                 if (!string.IsNullOrEmpty(Details.LinkName))
                 {
-                    var parent = new FluentCommand(Details.Parent).Resolve();
+                    var parent = new FluentCommand(Details.Parent).Resolve(this.Session);
                     var collectionName = this.Session.Metadata.GetNavigationPropertyPartnerTypeName(
                         parent.EntityCollection.Name, Details.LinkName);
                     entityCollection = this.Session.Metadata.GetEntityCollection(collectionName);

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -33,7 +32,6 @@ namespace Simple.OData.Client
         private bool IsBatchResponse => this.Session == null;
 
         internal ITypeCache TypeCache => this.Session.TypeCache;
-
 
         internal EntityCollection EntityCollection
         {
@@ -135,9 +133,9 @@ namespace Simple.OData.Client
                 if (Details.NamedKeyValues == null)
                 {
                     var entityCollection = this.EntityCollection;
-                    if (Source.HasFunction)
+                    if (Source.Details.HasFunction)
                     {
-                        var collection = this.Session.Metadata.GetFunctionReturnCollection(Source.FunctionName);
+                        var collection = this.Session.Metadata.GetFunctionReturnCollection(Source.Details.FunctionName);
                         if (collection != null)
                         {
                             entityCollection = collection;
@@ -199,21 +197,11 @@ namespace Simple.OData.Client
             return this.Session.Adapter.GetCommandFormatter().FormatCommand(this);
         }
 
-        internal bool HasKey => Details.KeyValues != null && Details.KeyValues.Count > 0 || Details.NamedKeyValues != null && Details.NamedKeyValues.Count > 0;
-
-        internal bool HasFilter => !string.IsNullOrEmpty(Details.Filter) || !ReferenceEquals(Details.FilterExpression, null);
-
-        internal bool HasSearch => !string.IsNullOrEmpty(Details.Search);
-
-        public bool HasFunction => !string.IsNullOrEmpty(Details.FunctionName);
-
-        public bool HasAction => !string.IsNullOrEmpty(Details.ActionName);
-
         internal IDictionary<string, object> KeyValues
         {
             get
             {
-                if (!HasKey)
+                if (!Details.HasKey)
                     return null;
 
                 var keyNames = this.Session.Metadata.GetDeclaredKeyPropertyNames(this.EntityCollection.Name).ToList();

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -40,7 +40,7 @@ namespace Simple.OData.Client
                 EntityCollection entityCollection;
                 if (!string.IsNullOrEmpty(Details.LinkName))
                 {
-                    var parent = new FluentCommand(Details.Parent).Resolve(this.Session);
+                    var parent = new FluentCommand(this.Session, Details.Parent).Resolve(this.Session);
                     var collectionName = this.Session.Metadata.GetNavigationPropertyPartnerTypeName(
                         parent.EntityCollection.Name, Details.LinkName);
                     entityCollection = this.Session.Metadata.GetEntityCollection(collectionName);

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -1,0 +1,381 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Simple.OData.Client.Extensions;
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client
+{
+    // Although ResolvedCommand is never instantiated directly (only via ICommand interface)
+    // it's declared as public in order to resolve problem when it is used with dynamic C#
+    // For the same reason FluentClient is also declared as public
+    // More: http://bloggingabout.net/blogs/vagif/archive/2013/08/05/we-need-better-interoperability-between-dynamic-and-statically-compiled-c.aspx
+
+    public partial class ResolvedCommand
+    {
+        private readonly FluentCommand _command;
+        private readonly Session _session;
+        private readonly CommandDetails _details;
+
+        internal static readonly string ResultLiteral = "__result";
+        internal static readonly string AnnotationsLiteral = "__annotations";
+        internal static readonly string MediaEntityLiteral = "__entity";
+
+        internal ResolvedCommand(FluentCommand command, Session session)
+        {
+            _command = command;
+            _session = session;
+            _details = new CommandDetails(_command.Details);
+
+
+            if (_details.CollectionName == null && !ReferenceEquals(_command.Details.CollectionExpression, null))
+            {
+                For(_command.Details.CollectionExpression.AsString(_session));
+            }
+
+            if (_details.DerivedCollectionName == null && !ReferenceEquals(_command.Details.DerivedCollectionExpression, null))
+            {
+                As(_command.Details.DerivedCollectionExpression.AsString(_session));
+            }
+
+            if (_details.Filter == null && !ReferenceEquals(_command.Details.FilterExpression, null))
+            {
+                _details.NamedKeyValues = TryInterpretFilterExpressionAsKey(_command.Details.FilterExpression, out var isAlternateKey);
+                _details.IsAlternateKey = isAlternateKey;
+
+                if (_details.NamedKeyValues == null)
+                {
+                    var entityCollection = this.EntityCollection;
+                    if (_command.HasFunction)
+                    {
+                        var collection = _session.Metadata.GetFunctionReturnCollection(_command.FunctionName);
+                        if (collection != null)
+                        {
+                            entityCollection = collection;
+                        }
+                    }
+                    _details.Filter = _command.Details.FilterExpression.Format(
+                        new ExpressionContext(_session, entityCollection, null, this.DynamicPropertiesContainerName));
+                }
+                else
+                {
+                    _details.KeyValues = null;
+                    _details.TopCount = -1;
+                }
+                if (_command.Details.FilterExpression.HasTypeConstraint(_command.Details.DerivedCollectionName))
+                {
+                    _details.DerivedCollectionName = null;
+                }
+            }
+
+            if (_details.LinkName == null && !ReferenceEquals(_command.Details.LinkExpression, null))
+            {
+                Link(_command.Details.LinkExpression.AsString(_session));
+            }
+        }
+
+        public FluentCommand Source => _command; 
+
+        private bool IsBatchResponse => _session == null;
+
+        internal ITypeCache TypeCache => _session.TypeCache;
+
+        internal CommandDetails Details => _details;
+
+        internal EntityCollection EntityCollection
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_details.CollectionName) && string.IsNullOrEmpty(_details.LinkName))
+                    return null;
+
+                EntityCollection entityCollection;
+                if (!string.IsNullOrEmpty(_details.LinkName))
+                {
+                    var parent = new FluentCommand(_details.Parent).Resolve();
+                    var collectionName = _session.Metadata.GetNavigationPropertyPartnerTypeName(
+                        parent.EntityCollection.Name, _details.LinkName);
+                    entityCollection = _session.Metadata.GetEntityCollection(collectionName);
+                }
+                else
+                {
+                    entityCollection = _session.Metadata.GetEntityCollection(_details.CollectionName);
+                }
+
+                return string.IsNullOrEmpty(_details.DerivedCollectionName)
+                    ? entityCollection
+                    : _session.Metadata.GetDerivedEntityCollection(entityCollection, _details.DerivedCollectionName);
+            }
+        }
+
+        public string QualifiedEntityCollectionName
+        {
+            get
+            {
+                var entityCollection = this.EntityCollection;
+                return entityCollection.BaseEntityCollection == null
+                    ? entityCollection.Name
+                    : $"{entityCollection.BaseEntityCollection.Name}/{_session.Metadata.GetQualifiedTypeName(entityCollection.Name)}";
+            }
+        }
+
+        public string DynamicPropertiesContainerName => _details.DynamicPropertiesContainerName;
+
+        public ResolvedCommand For(string collectionName)
+        {
+            if (IsBatchResponse) return this;
+
+            var items = collectionName.Split('/');
+            if (items.Count() > 1)
+            {
+                _details.CollectionName = items[0];
+                _details.DerivedCollectionName = items[1];
+            }
+            else
+            {
+                _details.CollectionName = collectionName;
+            }
+            return this;
+        }
+
+        public ResolvedCommand As(string derivedCollectionName)
+        {
+            if (IsBatchResponse) return this;
+
+            _details.DerivedCollectionName = derivedCollectionName;
+            return this;
+        }
+
+        public ResolvedCommand Link(string linkName)
+        {
+            if (IsBatchResponse) return this;
+
+            _details.LinkName = linkName;
+            return this;
+        }
+
+        public ResolvedCommand Key(IDictionary<string, object> key)
+        {
+            if (IsBatchResponse) return this;
+
+            _details.KeyValues = null;
+            _details.NamedKeyValues = null;
+            _details.IsAlternateKey = false;
+
+            if (NamedKeyValuesMatchAnyKey(key, out var matchingKey, out bool isAlternateKey))
+            {
+                _details.NamedKeyValues = matchingKey.ToDictionary();
+                _details.IsAlternateKey = isAlternateKey;
+            }
+            else if (TryExtractKeyFromNamedValues(key, out var containedKey))
+            {
+                _details.NamedKeyValues = containedKey.ToDictionary();
+            }
+            //Validation could throw exception here
+
+            return this;
+        }
+
+        public Task<string> GetCommandTextAsync()
+        {
+            return GetCommandTextAsync(CancellationToken.None);
+        }
+
+        public async Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
+        {
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            return Format();
+        }
+
+        public bool FilterIsKey => _details.NamedKeyValues != null;
+
+        public IDictionary<string, object> FilterAsKey => _details.NamedKeyValues;
+
+        public ResolvedCommand WithCount()
+        {
+            if (IsBatchResponse) return this;
+
+            _details.IncludeCount = true;
+            return this;
+        }
+
+        public override string ToString()
+        {
+            return Format();
+        }
+
+        private string Format()
+        {
+            return _session.Adapter.GetCommandFormatter().FormatCommand(this);
+        }
+
+        internal bool HasKey => _details.KeyValues != null && _details.KeyValues.Count > 0 || _details.NamedKeyValues != null && _details.NamedKeyValues.Count > 0;
+
+        internal bool HasFilter => !string.IsNullOrEmpty(_details.Filter) || !ReferenceEquals(_details.FilterExpression, null);
+
+        internal bool HasSearch => !string.IsNullOrEmpty(_details.Search);
+
+        public bool HasFunction => !string.IsNullOrEmpty(_details.FunctionName);
+
+        public bool HasAction => !string.IsNullOrEmpty(_details.ActionName);
+
+        //internal IDictionary<string, object> KeyValues
+        //{
+        //    get
+        //    {
+        //        if (!HasKey)
+        //            return null;
+
+        //        return (_details.KeyValues?.Zip(
+        //                    _session.Metadata.GetDeclaredKeyPropertyNames(this.EntityCollection.Name)
+        //                    , (keyValue, keyName)
+        //                        => new KeyValuePair<string, object>(keyName, keyValue))
+        //            ??
+        //                _details.NamedKeyValues)
+        //            ?.ToDictionary(
+        //                    x => x.Key,
+        //                    x => x.Value is ODataExpression oDataExpression ? oDataExpression.Value : x.Value);
+        //    }
+        //}
+
+        internal IDictionary<string, object> KeyValues
+        {
+            get
+            {
+                if (!HasKey)
+                    return null;
+
+                var keyNames = _details.Session.Metadata.GetDeclaredKeyPropertyNames(this.EntityCollection.Name).ToList();
+                var namedKeyValues = new Dictionary<string, object>();
+                for (var index = 0; index < keyNames.Count; index++)
+                {
+                    var found = false;
+                    object keyValue = null;
+                    if (_details.NamedKeyValues != null && _details.NamedKeyValues.Count > 0)
+                    {
+                        keyValue = _details.NamedKeyValues.FirstOrDefault(x => _details.Session.Settings.NameMatchResolver.IsMatch(x.Key, keyNames[index])).Value;
+                        found = keyValue != null;
+                    }
+                    else if (_details.KeyValues != null && _details.KeyValues.Count >= index)
+                    {
+                        keyValue = _details.KeyValues[index];
+                        found = true;
+                    }
+                    if (found)
+                    {
+                        var value = keyValue is ODataExpression ?
+                            (keyValue as ODataExpression).Value :
+                            keyValue;
+                        namedKeyValues.Add(keyNames[index], value);
+                    }
+                }
+                return namedKeyValues;
+            }
+        }
+
+        internal IDictionary<string, object> CommandData
+        {
+            get
+            {
+                if (_details.EntryData == null)
+                    return new Dictionary<string, object>();
+                if (string.IsNullOrEmpty(_details.DynamicPropertiesContainerName))
+                    return _details.EntryData;
+
+                var entryData = new Dictionary<string, object>();
+                foreach (var key in _details.EntryData.Keys.Where(x =>
+                    !string.Equals(x, _details.DynamicPropertiesContainerName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    entryData.Add(key, _details.EntryData[key]);
+                }
+
+                if (_details.EntryData.TryGetValue(_details.DynamicPropertiesContainerName, out var dynamicProperties) && dynamicProperties != null)
+                {
+                    if (dynamicProperties is IDictionary<string, object> kv)
+                    {
+                        foreach (var key in kv.Keys)
+                        {
+                            entryData.Add(key, kv[key]);
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Property {_details.DynamicPropertiesContainerName} must implement IDictionary<string,object> interface");
+                    }
+                }
+
+                return entryData;
+            }
+        }
+
+        private IDictionary<string, object> TryInterpretFilterExpressionAsKey(ODataExpression expression, out bool isAlternateKey)
+        {
+            isAlternateKey = false;
+            var ok = false;
+
+            IDictionary<string, object> namedKeyValues = new Dictionary<string, object>();
+            if (!ReferenceEquals(expression, null))
+            {
+                ok = expression.ExtractLookupColumns(namedKeyValues);
+            }
+            if (!ok)
+                return null;
+
+            if (NamedKeyValuesMatchAnyKey(namedKeyValues, out var matchingNamedKeyValues, out isAlternateKey))
+                return matchingNamedKeyValues.ToIDictionary();
+
+            return null;
+        }
+
+        private bool NamedKeyValuesMatchAnyKey(IDictionary<string, object> namedKeyValues, out IEnumerable<KeyValuePair<string, object>> matchingNamedKeyValues, out bool isAlternateKey)
+        {
+            isAlternateKey = false;
+
+            if (NamedKeyValuesMatchPrimaryKey(namedKeyValues, out matchingNamedKeyValues))
+                return true;
+
+            if (NamedKeyValuesMatchAlternateKey(namedKeyValues, out matchingNamedKeyValues))
+            {
+                isAlternateKey = true;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool NamedKeyValuesMatchPrimaryKey(IDictionary<string, object> namedKeyValues, out IEnumerable<KeyValuePair<string, object>> matchingNamedKeyValues)
+        {
+            var keyNames = _session.Metadata.GetDeclaredKeyPropertyNames(this.EntityCollection.Name).ToList();
+
+            return Utils.NamedKeyValuesMatchKeyNames(namedKeyValues, _session.Settings.NameMatchResolver, keyNames, out matchingNamedKeyValues);
+        }
+
+        private bool NamedKeyValuesMatchAlternateKey(IDictionary<string, object> namedKeyValues, out IEnumerable<KeyValuePair<string, object>> alternateKeyNamedValues)
+        {
+            alternateKeyNamedValues = null;
+
+            var alternateKeys = _session.Metadata.GetAlternateKeyPropertyNames(this.EntityCollection.Name).ToList();
+
+            foreach (var alternateKey in alternateKeys)
+            {
+                if (Utils.NamedKeyValuesMatchKeyNames(namedKeyValues, _session.Settings.NameMatchResolver, alternateKey, out alternateKeyNamedValues))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private bool TryExtractKeyFromNamedValues(IDictionary<string, object> namedValues, out IEnumerable<KeyValuePair<string, object>> matchingNamedKeyValues)
+        {
+            return Utils.NamedKeyValuesContainKeyNames(namedValues,
+                _session.Settings.NameMatchResolver,
+                _session.Metadata.GetDeclaredKeyPropertyNames(this.EntityCollection.Name),
+                out matchingNamedKeyValues);
+        }
+    }
+}

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -16,7 +16,7 @@ namespace Simple.OData.Client
         {
             Source = command;
             Session = session;
-            Details = new CommandDetails(Source.Details);
+            Details = new FluentCommandDetails(Source.Details);
 
             EvaluateCollectionName();
             EvaluateDerivedCollectionName();
@@ -29,7 +29,7 @@ namespace Simple.OData.Client
 
         internal Session Session { get; private set; }
 
-        internal CommandDetails Details { get; private set; }
+        internal FluentCommandDetails Details { get; private set; }
 
         internal ITypeCache TypeCache => this.Session.TypeCache;
 

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -28,8 +28,8 @@ namespace Simple.OData.Client
         public FluentCommand Source { get; private set; }
 
         internal Session Session { get; private set; }
+
         internal CommandDetails Details { get; private set; }
-        private bool IsBatchResponse => this.Session == null;
 
         internal ITypeCache TypeCache => this.Session.TypeCache;
 
@@ -74,8 +74,6 @@ namespace Simple.OData.Client
 
         private void EvaluateCollectionName()
         {
-            if (IsBatchResponse) return;
-
             if (Details.CollectionName == null && !ReferenceEquals(Source.Details.CollectionExpression, null))
             {
                 var collectionName = Source.Details.CollectionExpression.AsString(this.Session);
@@ -94,8 +92,6 @@ namespace Simple.OData.Client
 
         private void EvaluateDerivedCollectionName()
         {
-            if (IsBatchResponse) return;
-
             if (Details.DerivedCollectionName == null && !ReferenceEquals(Source.Details.DerivedCollectionExpression, null))
             {
                 var derivedCollectionName = Source.Details.DerivedCollectionExpression.AsString(this.Session);
@@ -158,8 +154,6 @@ namespace Simple.OData.Client
 
         private void EvaluateLinkName()
         {
-            if (IsBatchResponse) return;
-
             if (Details.LinkName == null && !ReferenceEquals(Source.Details.LinkExpression, null))
             {
                 Details.LinkName = Source.Details.LinkExpression.AsString(this.Session);
@@ -181,8 +175,6 @@ namespace Simple.OData.Client
 
         public ResolvedCommand WithCount()
         {
-            if (IsBatchResponse) return this;
-
             Details.IncludeCount = true;
             return this;
         }

--- a/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/ResolvedCommand.cs
@@ -17,11 +17,11 @@ namespace Simple.OData.Client
             Session = session;
             Details = new FluentCommandDetails(command.Details);
 
-            EvaluateCollectionName(command.Details);
-            EvaluateDerivedCollectionName(command.Details);
-            EvaluateNamedKeyValues(command.Details);
-            EvaluateFilter(command.Details);
-            EvaluateLinkName(command.Details);
+            ResolveCollectionName(command.Details);
+            ResolveDerivedCollectionName(command.Details);
+            ResolveLinkName(command.Details);
+            ResolveNamedKeyValues(command.Details);
+            ResolveFilter(command.Details);
         }
 
         internal Session Session { get; private set; }
@@ -69,7 +69,7 @@ namespace Simple.OData.Client
 
         public string DynamicPropertiesContainerName => Details.DynamicPropertiesContainerName;
 
-        private void EvaluateCollectionName(FluentCommandDetails details)
+        private void ResolveCollectionName(FluentCommandDetails details)
         {
             if (Details.CollectionName == null && !ReferenceEquals(details.CollectionExpression, null))
             {
@@ -87,7 +87,7 @@ namespace Simple.OData.Client
             }
         }
 
-        private void EvaluateDerivedCollectionName(FluentCommandDetails details)
+        private void ResolveDerivedCollectionName(FluentCommandDetails details)
         {
             if (Details.DerivedCollectionName == null && !ReferenceEquals(details.DerivedCollectionExpression, null))
             {
@@ -96,7 +96,15 @@ namespace Simple.OData.Client
             }
         }
 
-        private void EvaluateNamedKeyValues(FluentCommandDetails details)
+        private void ResolveLinkName(FluentCommandDetails details)
+        {
+            if (Details.LinkName == null && !ReferenceEquals(details.LinkExpression, null))
+            {
+                Details.LinkName = details.LinkExpression.AsString(this.Session);
+            }
+        }
+
+        private void ResolveNamedKeyValues(FluentCommandDetails details)
         {
             if (Details.NamedKeyValues != null)
             {
@@ -116,7 +124,7 @@ namespace Simple.OData.Client
             }
         }
 
-        private void EvaluateFilter(FluentCommandDetails details)
+        private void ResolveFilter(FluentCommandDetails details)
         {
             if (Details.Filter == null && !ReferenceEquals(details.FilterExpression, null))
             {
@@ -146,14 +154,6 @@ namespace Simple.OData.Client
                 {
                     Details.DerivedCollectionName = null;
                 }
-            }
-        }
-
-        private void EvaluateLinkName(FluentCommandDetails details)
-        {
-            if (Details.LinkName == null && !ReferenceEquals(details.LinkExpression, null))
-            {
-                Details.LinkName = details.LinkExpression.AsString(this.Session);
             }
         }
 

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -347,7 +347,7 @@ namespace Simple.OData.Client
             var command = GetBoundClient()
                 .For(collection)
                 .Key(entryKey)
-                .AsBoundClient().Command.Resolve();
+                .AsBoundClient().Command.Resolve(_session);
 
             var requestBuilder = new RequestBuilder(command, _session, this.BatchWriter);
             var request = await requestBuilder.GetRequestAsync(false, cancellationToken).ConfigureAwait(false);
@@ -573,7 +573,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            var result = await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
+            var result = await ExecuteFunctionAsync(command.Resolve(_session), cancellationToken).ConfigureAwait(false);
             return result?.FirstOrDefault();
         }
 
@@ -595,7 +595,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            return await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
+            return await ExecuteFunctionAsync(command.Resolve(_session), cancellationToken).ConfigureAwait(false);
         }
 
         public Task<T> ExecuteFunctionAsScalarAsync<T>(string functionName, IDictionary<string, object> parameters)
@@ -654,7 +654,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
+            await ExecuteActionAsync(command.Resolve(_session), cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> ExecuteActionAsSingleAsync(string actionName, IDictionary<string, object> parameters)
@@ -675,7 +675,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            var result = await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
+            var result = await ExecuteActionAsync(command.Resolve(_session), cancellationToken).ConfigureAwait(false);
             return result?.FirstOrDefault();
         }
 
@@ -697,7 +697,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            return await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
+            return await ExecuteActionAsync(command.Resolve(_session), cancellationToken).ConfigureAwait(false);
         }
 
         public Task<T> ExecuteActionAsScalarAsync<T>(string actionName, IDictionary<string, object> parameters)
@@ -822,7 +822,7 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = await FindAnnotatedEntriesAsync(commandText, scalarResult, annotations, cancellationToken).ConfigureAwait(false);
@@ -840,7 +840,7 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var results = await FindAnnotatedEntriesAsync(commandText, false, null, cancellationToken).ConfigureAwait(false);
@@ -859,7 +859,7 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await FindScalarAsync(commandText, cancellationToken).ConfigureAwait(false);
@@ -870,7 +870,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry(false);
 
-            var resolvedCommand = command.Resolve();
+            var resolvedCommand = command.Resolve(_session);
             var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.InsertRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -894,7 +894,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry(false);
 
-            var resolvedCommand = command.Resolve();
+            var resolvedCommand = command.Resolve(_session);
             var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.UpdateRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -907,7 +907,7 @@ namespace Simple.OData.Client
             {
                 try
                 {
-                    result = await GetUpdatedResult(resolvedCommand.Source, cancellationToken).ConfigureAwait(false);
+                    result = await GetUpdatedResult(resolvedCommand, cancellationToken).ConfigureAwait(false);
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                 }
                 catch (Exception)
@@ -958,7 +958,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            var requestBuilder = new RequestBuilder(command.Resolve(), _session, this.BatchWriter);
+            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.DeleteRequestAsync(cancellationToken).ConfigureAwait(false);
             if (!IsBatchRequest)
             {
@@ -987,7 +987,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            var requestBuilder = new RequestBuilder(command.Resolve(), _session, this.BatchWriter);
+            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.LinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
@@ -1004,7 +1004,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            var requestBuilder = new RequestBuilder(command.Resolve(), _session, this.BatchWriter);
+            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.UnlinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
@@ -1024,7 +1024,7 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await GetMediaStreamAsync(commandText, cancellationToken).ConfigureAwait(false);
@@ -1038,7 +1038,7 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             await SetMediaStreamAsync(commandText, stream, contentType, optimisticConcurrency, cancellationToken).ConfigureAwait(false);
@@ -1069,10 +1069,11 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
+            var resolvedCommand = command.Resolve(_session);
             if (command.HasFunction)
-                return await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
+                return await ExecuteFunctionAsync(resolvedCommand, cancellationToken).ConfigureAwait(false);
             else if (command.HasAction)
-                return await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
+                return await ExecuteActionAsync(resolvedCommand, cancellationToken).ConfigureAwait(false);
             else
                 throw new InvalidOperationException("Command is expected to be a function or an action.");
         }

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -871,6 +871,9 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry(false);
 
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var resolvedCommand = command.Resolve(_session);
             var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.InsertRequestAsync(resultRequired, cancellationToken).ConfigureAwait(false);
@@ -894,6 +897,9 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse)
                 return _batchResponse.AsEntry(false);
+
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var resolvedCommand = command.Resolve(_session);
             var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
@@ -959,6 +965,9 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.DeleteRequestAsync(cancellationToken).ConfigureAwait(false);
             if (!IsBatchRequest)
@@ -988,6 +997,9 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+
             var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.LinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
@@ -1004,6 +1016,9 @@ namespace Simple.OData.Client
         {
             if (IsBatchResponse)
                 return;
+
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
             var request = await requestBuilder.UnlinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -1102,7 +1102,7 @@ namespace Simple.OData.Client
                 ? default(T)
                 : result == null 
                 ? default(T) 
-                : command.TypeCache.Convert<T>(result.First().Value);
+                : _session.TypeCache.Convert<T>(result.First().Value);
         }
 
         internal async Task<T[]> ExecuteAsArrayAsync<T>(FluentCommand command, CancellationToken cancellationToken)
@@ -1116,8 +1116,8 @@ namespace Simple.OData.Client
                 : result == null
                 ? null
                 : typeof(T) == typeof(string) || typeof(T).IsValue()
-                ? result.SelectMany(x => x.Values).Select(x => command.TypeCache.Convert<T>(x)).ToArray()
-                : result.Select(x => (T)x.ToObject(command.TypeCache, typeof(T))).ToArray();
+                ? result.SelectMany(x => x.Values).Select(x => _session.TypeCache.Convert<T>(x)).ToArray()
+                : result.Select(x => (T)x.ToObject(_session.TypeCache, typeof(T))).ToArray();
         }
 
         internal async Task ExecuteBatchAsync(IList<Func<IODataClient, Task>> actions, CancellationToken cancellationToken)

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -822,13 +822,14 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var resolvedCommand = command.Resolve(_session);
+            var commandText = await resolvedCommand.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = await FindAnnotatedEntriesAsync(commandText, scalarResult, annotations, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            await EnrichWithMediaPropertiesAsync(result, command, cancellationToken).ConfigureAwait(false);
+            await EnrichWithMediaPropertiesAsync(result, resolvedCommand, cancellationToken).ConfigureAwait(false);
             return result?.Select(x => x.GetData(_session.Settings.IncludeAnnotationsInResults));
         }
 
@@ -948,7 +949,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await IterateEntriesAsync(
-                command, resultRequired,
+                command.Resolve(_session), resultRequired,
                 async (x, y, z, w) => await UpdateEntryAsync(x, y, z, w, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }
@@ -977,7 +978,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await IterateEntriesAsync(
-                command,
+                command.Resolve(_session),
                 async (x, y) => await DeleteEntryAsync(x, y, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -876,7 +876,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = await ExecuteRequestWithResultAsync(request, cancellationToken,
-                x => x.AsEntry(_session.Settings.IncludeAnnotationsInResults), () => null, () => command.CommandData).ConfigureAwait(false);
+                x => x.AsEntry(_session.Settings.IncludeAnnotationsInResults), () => null, () => resolvedCommand.CommandData).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var keyNames = _session.Metadata.GetDeclaredKeyPropertyNames(resolvedCommand.QualifiedEntityCollectionName);
@@ -927,7 +927,7 @@ namespace Simple.OData.Client
             {
                 try
                 {
-                    var entryKey = resolvedCommand.HasKey ? resolvedCommand.KeyValues : resolvedCommand.FilterAsKey;
+                    var entryKey = resolvedCommand.Details.HasKey ? resolvedCommand.KeyValues : resolvedCommand.FilterAsKey;
                     await UnlinkEntryAsync(resolvedCommand.QualifiedEntityCollectionName, entryKey, associationName, cancellationToken).ConfigureAwait(false);
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                 }
@@ -1070,9 +1070,9 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var resolvedCommand = command.Resolve(_session);
-            if (command.HasFunction)
+            if (command.Details.HasFunction)
                 return await ExecuteFunctionAsync(resolvedCommand, cancellationToken).ConfigureAwait(false);
-            else if (command.HasAction)
+            else if (command.Details.HasAction)
                 return await ExecuteActionAsync(resolvedCommand, cancellationToken).ConfigureAwait(false);
             else
                 throw new InvalidOperationException("Command is expected to be a function or an action.");

--- a/src/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -823,10 +823,8 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var resolvedCommand = command.Resolve(_session);
-            var commandText = await resolvedCommand.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await FindAnnotatedEntriesAsync(commandText, scalarResult, annotations, cancellationToken).ConfigureAwait(false);
+            var result = await FindAnnotatedEntriesAsync(resolvedCommand.Format(), scalarResult, annotations, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             await EnrichWithMediaPropertiesAsync(result, resolvedCommand, cancellationToken).ConfigureAwait(false);
@@ -841,10 +839,9 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+            var resolvedCommand = command.Resolve(_session);
 
-            var results = await FindAnnotatedEntriesAsync(commandText, false, null, cancellationToken).ConfigureAwait(false);
+            var results = await FindAnnotatedEntriesAsync(resolvedCommand.Format(), false, null, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
             var result = results?.FirstOrDefault();
 
@@ -860,10 +857,9 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
+            var resolvedCommand = command.Resolve(_session);
 
-            return await FindScalarAsync(commandText, cancellationToken).ConfigureAwait(false);
+            return await FindScalarAsync(resolvedCommand.Format(), cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IDictionary<string, object>> InsertEntryAsync(FluentCommand command, bool resultRequired, CancellationToken cancellationToken)
@@ -954,8 +950,10 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
+            var resolvedCommand = command.Resolve(_session);
+
             return await IterateEntriesAsync(
-                command.Resolve(_session), resultRequired,
+                resolvedCommand, resultRequired,
                 async (x, y, z, w) => await UpdateEntryAsync(x, y, z, w, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }
@@ -968,7 +966,8 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
+            var resolvedCommand = command.Resolve(_session);
+            var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.DeleteRequestAsync(cancellationToken).ConfigureAwait(false);
             if (!IsBatchRequest)
             {
@@ -986,8 +985,9 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
+            var resolvedCommand = command.Resolve(_session);
             return await IterateEntriesAsync(
-                command.Resolve(_session),
+                resolvedCommand,
                 async (x, y) => await DeleteEntryAsync(x, y, cancellationToken).ConfigureAwait(false),
                 cancellationToken).ConfigureAwait(false);
         }
@@ -1000,7 +1000,8 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
+            var resolvedCommand = command.Resolve(_session);
+            var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.LinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
@@ -1019,8 +1020,9 @@ namespace Simple.OData.Client
 
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
-
-            var requestBuilder = new RequestBuilder(command.Resolve(_session), _session, this.BatchWriter);
+            
+            var resolvedCommand = command.Resolve(_session);
+            var requestBuilder = new RequestBuilder(resolvedCommand, _session, this.BatchWriter);
             var request = await requestBuilder.UnlinkRequestAsync(linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
@@ -1040,10 +1042,8 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
-
-            return await GetMediaStreamAsync(commandText, cancellationToken).ConfigureAwait(false);
+            var resolvedCommand = command.Resolve(_session);
+            return await GetMediaStreamAsync(resolvedCommand.Format(), cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task SetMediaStreamAsync(FluentCommand command, Stream stream, string contentType, bool optimisticConcurrency, CancellationToken cancellationToken)
@@ -1054,10 +1054,8 @@ namespace Simple.OData.Client
             await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
-            if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
-
-            await SetMediaStreamAsync(commandText, stream, contentType, optimisticConcurrency, cancellationToken).ConfigureAwait(false);
+            var resolvedCommand = command.Resolve(_session);
+            await SetMediaStreamAsync(resolvedCommand.Format(), stream, contentType, optimisticConcurrency, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task ExecuteAsync(FluentCommand command, CancellationToken cancellationToken)

--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -278,7 +278,7 @@ namespace Simple.OData.Client
         {
             var entryIdent = command.Details.HasKey
                 ? await command.Resolve(_session).GetCommandTextAsync(cancellationToken)
-.ConfigureAwait(false) : await (new FluentCommand(command).Key(command.Details.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
+.ConfigureAwait(false) : await (new FluentCommand(command.Session, command.Details).Key(command.Details.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }

--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -21,7 +21,7 @@ namespace Simple.OData.Client
             {
                 updatedKey.Add(item);
             }
-            var updatedCommand = new FluentCommand(command.Source).Key(updatedKey);
+            var updatedCommand = new FluentCommand(command).Key(updatedKey);
             return await FindEntryAsync(await updatedCommand.Resolve(_session).GetCommandTextAsync(cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
         }
 
@@ -31,7 +31,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateFunctionRequestAsync(commandText, command.Source.Details.FunctionName).ConfigureAwait(false);
+                .CreateFunctionRequestAsync(commandText, command.Details.FunctionName).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(_session.Settings.IncludeAnnotationsInResults),
@@ -47,7 +47,7 @@ namespace Simple.OData.Client
                 ? _session.Metadata.GetQualifiedTypeName(command.EntityCollection.Name)
                 : null;
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateActionRequestAsync(commandText, command.Source.Details.ActionName, entityTypeName, command.CommandData, true).ConfigureAwait(false);
+                .CreateActionRequestAsync(commandText, command.Details.ActionName, entityTypeName, command.CommandData, true).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(_session.Settings.IncludeAnnotationsInResults),

--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -164,13 +164,12 @@ namespace Simple.OData.Client
         }
 
         private async Task<IEnumerable<IDictionary<string, object>>> IterateEntriesAsync(
-            FluentCommand command, bool resultRequired,
+            ResolvedCommand command, bool resultRequired,
             Func<string, IDictionary<string, object>, IDictionary<string, object>, bool, Task<IDictionary<string, object>>> funcAsync, CancellationToken cancellationToken)
         {
-            var resolvedCommand = command.Resolve(_session);
-            var collectionName = resolvedCommand.QualifiedEntityCollectionName;
-            var entryData = resolvedCommand.CommandData;
-            var commandText = await resolvedCommand.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var collectionName = command.QualifiedEntityCollectionName;
+            var entryData = command.CommandData;
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             IEnumerable<IDictionary<string, object>> result = null;
@@ -191,12 +190,11 @@ namespace Simple.OData.Client
             return result;
         }
 
-        private async Task<int> IterateEntriesAsync(FluentCommand command,
+        private async Task<int> IterateEntriesAsync(ResolvedCommand command,
             Func<string, IDictionary<string, object>, Task> funcAsync, CancellationToken cancellationToken)
         {
-            var resolvedCommand = command.Resolve(_session);
-            var collectionName = resolvedCommand.QualifiedEntityCollectionName;
-            var commandText = await resolvedCommand.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
+            var collectionName = command.QualifiedEntityCollectionName;
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = 0;
@@ -258,7 +256,7 @@ namespace Simple.OData.Client
             }
         }
 
-        private void AssertHasKey(FluentCommand command)
+        private void AssertHasKey(ResolvedCommand command)
         {
             if (!command.Details.HasKey && command.Details.FilterAsKey == null)
                 throw new InvalidOperationException("No entry key specified.");
@@ -274,16 +272,16 @@ namespace Simple.OData.Client
             return entryIdent;
         }
 
-        private async Task<string> FormatEntryKeyAsync(FluentCommand command, CancellationToken cancellationToken)
+        private async Task<string> FormatEntryKeyAsync(ResolvedCommand command, CancellationToken cancellationToken)
         {
             var entryIdent = command.Details.HasKey
-                ? await command.Resolve(_session).GetCommandTextAsync(cancellationToken)
-.ConfigureAwait(false) : await (new FluentCommand(command.Session, command.Details).Key(command.Details.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
+                ? await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false) 
+                : await (new FluentCommand(command.Session, command.Details).Key(command.Details.FilterAsKey).Resolve(_session).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }
 
-        private async Task EnrichWithMediaPropertiesAsync(IEnumerable<AnnotatedEntry> entries, FluentCommand command, CancellationToken cancellationToken)
+        private async Task EnrichWithMediaPropertiesAsync(IEnumerable<AnnotatedEntry> entries, ResolvedCommand command, CancellationToken cancellationToken)
         {
             if (entries != null)
             {

--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -266,7 +266,7 @@ namespace Simple.OData.Client
         {
             var entryIdent = command.Details.HasKey
                 ? command.Format() 
-                : new FluentCommand(command.Session, command.Details).Key(command.Details.FilterAsKey).Resolve(_session).Format();
+                : new FluentCommand(command.Details).Key(command.Details.FilterAsKey).Resolve(_session).Format();
 
             return entryIdent;
         }

--- a/src/Simple.OData.Client.V3.Adapter/CommandFormatter.cs
+++ b/src/Simple.OData.Client.V3.Adapter/CommandFormatter.cs
@@ -30,7 +30,7 @@ namespace Simple.OData.Client.V3.Adapter
                 : ConvertValue(value);
         }
 
-        protected override void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, FluentCommand command)
+        protected override void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, ResolvedCommand command)
         {
             FormatClause(commandClauses, resultCollection, command.Details.ExpandAssociations, ODataLiteral.Expand, FormatExpandItem);
             FormatClause(commandClauses, resultCollection, command.Details.SelectColumns, ODataLiteral.Select, FormatSelectItem);

--- a/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
@@ -39,7 +39,7 @@ namespace Simple.OData.Client.V4.Adapter
                 : ConvertValue(value);
         }
 
-        protected override void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, FluentCommand command)
+        protected override void FormatExpandSelectOrderby(IList<string> commandClauses, EntityCollection resultCollection, ResolvedCommand command)
         {
             if (command.Details.ExpandAssociations.Any())
             {


### PR DESCRIPTION
This is a rather big PR with the following goal:

- Remove Session field from FluentCommand. FluentCommand needs to be decoupled from the schema, it should be similar to SQL command before preparation, just a set of instructions that will be later mapped to OData resources and converted into an HTTP request.
- Introduce ResolvedCommand that is a served as a prepared OData command, it is transformed from a FluentCommand by applying OData schema and then mapping to actual OData resources and properties.