### PR TITLE
Ability to add http headers from the fluent API.

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/IRequestWriter.cs
+++ b/src/Simple.OData.Client.Core/Adapter/IRequestWriter.cs
@@ -12,7 +12,7 @@ namespace Simple.OData.Client
         Task<ODataRequest> CreatePutRequestAsync(string commandText, Stream stream, string contentType, bool optimisticConcurrency, IDictionary<string, string> headers = null);
         Task<ODataRequest> CreateInsertRequestAsync(string collection, string commandText, IDictionary<string, object> entryData, bool resultRequired, IDictionary<string, string> headers = null);
         Task<ODataRequest> CreateUpdateRequestAsync(string collection, string entryIdent, IDictionary<string, object> entryKey, IDictionary<string, object> entryData, bool resultRequired, IDictionary<string, string> headers = null);
-        Task<ODataRequest> CreateDeleteRequestAsync(string collection, string entryIdent, IDictionary<string, string> headers);
+        Task<ODataRequest> CreateDeleteRequestAsync(string collection, string entryIdent, IDictionary<string, string> headers = null);
         Task<ODataRequest> CreateLinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent, IDictionary<string, string> headers = null);
         Task<ODataRequest> CreateUnlinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent, IDictionary<string, string> headers = null);
         Task<ODataRequest> CreateFunctionRequestAsync(string commandText, string functionName, IDictionary<string, string> headers = null);

--- a/src/Simple.OData.Client.Core/Adapter/IRequestWriter.cs
+++ b/src/Simple.OData.Client.Core/Adapter/IRequestWriter.cs
@@ -8,14 +8,14 @@ namespace Simple.OData.Client
 {
     public interface IRequestWriter
     {
-        Task<ODataRequest> CreateGetRequestAsync(string commandText, bool scalarResult);
-        Task<ODataRequest> CreatePutRequestAsync(string commandText, Stream stream, string contentType, bool optimisticConcurrency);
-        Task<ODataRequest> CreateInsertRequestAsync(string collection, string commandText, IDictionary<string, object> entryData, bool resultRequired);
-        Task<ODataRequest> CreateUpdateRequestAsync(string collection, string entryIdent, IDictionary<string, object> entryKey, IDictionary<string, object> entryData, bool resultRequired);
-        Task<ODataRequest> CreateDeleteRequestAsync(string collection, string entryIdent);
-        Task<ODataRequest> CreateLinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent);
-        Task<ODataRequest> CreateUnlinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent);
-        Task<ODataRequest> CreateFunctionRequestAsync(string commandText, string functionName);
-        Task<ODataRequest> CreateActionRequestAsync(string commandText, string actionName, string boundTypeName, IDictionary<string, object> parameters, bool resultRequired);
+        Task<ODataRequest> CreateGetRequestAsync(string commandText, bool scalarResult, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreatePutRequestAsync(string commandText, Stream stream, string contentType, bool optimisticConcurrency, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateInsertRequestAsync(string collection, string commandText, IDictionary<string, object> entryData, bool resultRequired, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateUpdateRequestAsync(string collection, string entryIdent, IDictionary<string, object> entryKey, IDictionary<string, object> entryData, bool resultRequired, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateDeleteRequestAsync(string collection, string entryIdent, IDictionary<string, string> headers);
+        Task<ODataRequest> CreateLinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateUnlinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateFunctionRequestAsync(string commandText, string functionName, IDictionary<string, string> headers = null);
+        Task<ODataRequest> CreateActionRequestAsync(string commandText, string actionName, string boundTypeName, IDictionary<string, object> parameters, bool resultRequired, IDictionary<string, string> headers = null);
     }
 }

--- a/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -89,6 +89,18 @@ namespace Simple.OData.Client
             return this as FT;
         }
 
+        public FT WithHeader(string name, string value)
+        {
+            this.Command.WithHeader(name, value);
+            return this as FT;
+        }
+        
+        public FT WithHeaders(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            this.Command.WithHeaders(headers);
+            return this as FT;
+        }
+
         public FT Key(params object[] entryKey)
         {
             this.Command.Key(entryKey);

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -349,18 +349,12 @@ namespace Simple.OData.Client
 
         public FluentCommand WithHeader(string name, string value)
         {
-            if (Details.Headers is null)
-                Details.Headers = new Dictionary<string, string>();
-
             Details.Headers[name] = value;
             return this;
         }
 
         public FluentCommand WithHeaders(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            if (Details.Headers is null)
-                Details.Headers = new Dictionary<string, string>();
-
             foreach (var header in headers)
                 Details.Headers[header.Key] = header.Value;
             return this;

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -347,6 +347,25 @@ namespace Simple.OData.Client
             return this;
         }
 
+        public FluentCommand WithHeader(string name, string value)
+        {
+            if (Details.Headers is null)
+                Details.Headers = new Dictionary<string, string>();
+
+            Details.Headers[name] = value;
+            return this;
+        }
+
+        public FluentCommand WithHeaders(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            if (Details.Headers is null)
+                Details.Headers = new Dictionary<string, string>();
+
+            foreach (var header in headers)
+                Details.Headers[header.Key] = header.Value;
+            return this;
+        }
+
         internal IList<string> SelectedColumns => Details.SelectColumns;
 
         private IEnumerable<string> SplitItems(IEnumerable<string> columns)

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
@@ -36,6 +36,7 @@ namespace Simple.OData.Client
         public string MediaName { get; set; }
         public IEnumerable<string> MediaProperties { get; set; }
         public ConcurrentDictionary<object, IDictionary<string, object>> BatchEntries { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
 
         public FluentCommandDetails(FluentCommandDetails parent, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
         {
@@ -47,6 +48,7 @@ namespace Simple.OData.Client
             this.OrderbyColumns = new List<KeyValuePair<string, bool>>();
             this.MediaProperties = new List<string>();
             this.BatchEntries = batchEntries;
+            this.Headers = new Dictionary<string, string>();
         }
 
         public FluentCommandDetails(FluentCommandDetails details)

--- a/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
+++ b/src/Simple.OData.Client.Core/Fluent/FluentCommandDetails.cs
@@ -84,6 +84,7 @@ namespace Simple.OData.Client
             this.QueryOptionsKeyValues = details.QueryOptionsKeyValues;
             this.QueryOptionsExpression = details.QueryOptionsExpression;
             this.BatchEntries = details.BatchEntries;
+            this.Headers = details.Headers;
         }
 
         public bool HasKey => this.KeyValues != null && this.KeyValues.Count > 0 || this.NamedKeyValues != null && this.NamedKeyValues.Count > 0;

--- a/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
@@ -295,6 +295,21 @@ namespace Simple.OData.Client
         FT QueryOptions<U>(Expression<Func<U, bool>> expression);
 
         /// <summary>
+        /// Adds an header to be included in the http request.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The header value.</param>
+        /// <returns>Self.</returns>
+        FT WithHeader(string name, string value);
+        /// <summary>
+        /// Adds a collection of header to be included in the http request.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The header value.</param>
+        /// <returns>Self.</returns>
+        FT WithHeaders(IEnumerable<KeyValuePair<string, string>> headers);
+
+        /// <summary>
         /// Selects retrieval of an entity media stream.
         /// </summary>
         /// <returns>Self.</returns>

--- a/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
+++ b/src/Simple.OData.Client.Core/Fluent/IFluentClient.cs
@@ -295,14 +295,14 @@ namespace Simple.OData.Client
         FT QueryOptions<U>(Expression<Func<U, bool>> expression);
 
         /// <summary>
-        /// Adds an header to be included in the http request.
+        /// Adds an header to be included in the HTTP request.
         /// </summary>
         /// <param name="name">The header name.</param>
         /// <param name="value">The header value.</param>
         /// <returns>Self.</returns>
         FT WithHeader(string name, string value);
         /// <summary>
-        /// Adds a collection of header to be included in the http request.
+        /// Adds a collection of header to be included in the HTTP request.
         /// </summary>
         /// <param name="name">The header name.</param>
         /// <param name="value">The header value.</param>

--- a/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
+++ b/src/Simple.OData.Client.Core/Fluent/RequestBuilder.cs
@@ -33,7 +33,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateGetRequestAsync(_commandText ?? _command.Format(), scalarResult).ConfigureAwait(false);
+                .CreateGetRequestAsync(_commandText ?? _command.Format(), scalarResult, _command.Details.Headers).ConfigureAwait(false);
         }
 
         public async Task<ODataRequest> InsertRequestAsync(bool resultRequired, CancellationToken cancellationToken)
@@ -44,7 +44,7 @@ namespace Simple.OData.Client
             var entryData = _command.CommandData;
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateInsertRequestAsync(_command.QualifiedEntityCollectionName, _command.Format(), entryData, resultRequired).ConfigureAwait(false);
+                .CreateInsertRequestAsync(_command.QualifiedEntityCollectionName, _command.Format(), entryData, resultRequired, _command.Details.Headers).ConfigureAwait(false);
         }
 
         public async Task<ODataRequest> UpdateRequestAsync(bool resultRequired, CancellationToken cancellationToken)
@@ -60,7 +60,7 @@ namespace Simple.OData.Client
             var entryIdent = FormatEntryKey(_command);
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateUpdateRequestAsync(collectionName, entryIdent, entryKey, entryData, resultRequired).ConfigureAwait(false);
+                .CreateUpdateRequestAsync(collectionName, entryIdent, entryKey, entryData, resultRequired, _command.Details.Headers).ConfigureAwait(false);
         }
 
         public async Task<ODataRequest> UpdateRequestAsync(Stream stream, string contentType, bool optimisticConcurrency, CancellationToken cancellationToken)
@@ -69,7 +69,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreatePutRequestAsync(_commandText, stream, contentType, optimisticConcurrency).ConfigureAwait(false);            
+                .CreatePutRequestAsync(_commandText, stream, contentType, optimisticConcurrency, _command.Details.Headers).ConfigureAwait(false);            
         }
 
         public async Task<ODataRequest> DeleteRequestAsync(CancellationToken cancellationToken)
@@ -83,7 +83,7 @@ namespace Simple.OData.Client
             var entryIdent = FormatEntryKey(_command);
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateDeleteRequestAsync(collectionName, entryIdent).ConfigureAwait(false);
+                .CreateDeleteRequestAsync(collectionName, entryIdent, _command.Details.Headers).ConfigureAwait(false);
         }
 
         public async Task<ODataRequest> LinkRequestAsync(string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
@@ -104,7 +104,7 @@ namespace Simple.OData.Client
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateLinkRequestAsync(collectionName, linkName, entryIdent, linkIdent).ConfigureAwait(false);
+                .CreateLinkRequestAsync(collectionName, linkName, entryIdent, linkIdent, _command.Details.Headers).ConfigureAwait(false);
         }
 
         public async Task<ODataRequest> UnlinkRequestAsync(string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
@@ -129,7 +129,7 @@ namespace Simple.OData.Client
             }
 
             return await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateUnlinkRequestAsync(collectionName, linkName, entryIdent, linkIdent).ConfigureAwait(false);
+                .CreateUnlinkRequestAsync(collectionName, linkName, entryIdent, linkIdent, _command.Details.Headers).ConfigureAwait(false);
         }
 
         private string FormatEntryKey(ResolvedCommand command)

--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -28,7 +28,7 @@ namespace Simple.OData.Client
         private async Task<IEnumerable<IDictionary<string, object>>> ExecuteFunctionAsync(ResolvedCommand command, CancellationToken cancellationToken)
         {
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateFunctionRequestAsync(command.Format(), command.Details.FunctionName).ConfigureAwait(false);
+                .CreateFunctionRequestAsync(command.Format(), command.Details.FunctionName, command.Details.Headers).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(_session.Settings.IncludeAnnotationsInResults),
@@ -41,7 +41,7 @@ namespace Simple.OData.Client
                 ? _session.Metadata.GetQualifiedTypeName(command.EntityCollection.Name)
                 : null;
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateActionRequestAsync(command.Format(), command.Details.ActionName, entityTypeName, command.CommandData, true).ConfigureAwait(false);
+                .CreateActionRequestAsync(command.Format(), command.Details.ActionName, entityTypeName, command.CommandData, true, command.Details.Headers).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(_session.Settings.IncludeAnnotationsInResults),

--- a/src/Simple.OData.Client.Core/ODataRequest.cs
+++ b/src/Simple.OData.Client.Core/ODataRequest.cs
@@ -59,7 +59,7 @@ namespace Simple.OData.Client
         public bool CheckOptimisticConcurrency { get; set; }
         public readonly IDictionary<string, string> Headers = new Dictionary<string, string>();
 
-        internal ODataRequest(string method, ISession session, string commandText)
+        internal ODataRequest(string method, ISession session, string commandText, IDictionary<string, string> headers = null)
         {
             this.CommandText = commandText;
             this.Method = method;
@@ -69,6 +69,9 @@ namespace Simple.OData.Client
                 ? uri.AbsoluteUri
                 : Utils.CreateAbsoluteUri(session.Settings.BaseUri.AbsoluteUri, commandText).AbsoluteUri;
             _payloadFormat = session.Settings.PayloadFormat;
+            
+            if (headers != null)
+                Headers = headers;
         }
 
         internal ODataRequest(string method, ISession session, string commandText, HttpRequestMessage requestMessage)
@@ -77,8 +80,8 @@ namespace Simple.OData.Client
             this.RequestMessage = requestMessage;
         }
 
-        internal ODataRequest(string method, ISession session, string commandText, IDictionary<string, object> entryData, Stream contentStream, string mediaType = null)
-            : this(method, session, commandText)
+        internal ODataRequest(string method, ISession session, string commandText, IDictionary<string, object> entryData, Stream contentStream, string mediaType = null, IDictionary<string, string> headers = null)
+            : this(method, session, commandText, headers)
         {
             EntryData = entryData;
             _contentStream = contentStream;

--- a/src/Simple.OData.Client.UnitTests/Core/RequestWriterTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/RequestWriterTests.cs
@@ -215,5 +215,24 @@ namespace Simple.OData.Client.Tests.Core
                 }, false);
             Assert.Equal("POST", result.Method);
         }
+
+        [Fact]
+        public async Task CreateInsertRequest_With_Headers()
+        {
+            var requestWriter = await CreateRequestWriter();
+            var result = await requestWriter.CreateInsertRequestAsync("Employees", "",
+                new Dictionary<string, object>()
+                {
+                    { "FirstName", "John" },
+                }, false, 
+                new Dictionary<string, string>
+                {
+                    { "header1" , "header1Value" },
+                    { "header2" , "header2Value" }
+                });
+
+            Assert.Equal("header1Value", result.Headers["header1"]);
+            Assert.Equal("header2Value", result.Headers["header2"]);
+        }
     }
 }

--- a/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
@@ -64,7 +64,7 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .For("Products")
                 .Skip(1)
                 .FindEntriesAsync();
-            Assert.Equal(ExpectedCountOfProducts-1, products.Count());
+            Assert.Equal(ExpectedCountOfProducts - 1, products.Count());
         }
 
         [Fact]
@@ -250,7 +250,7 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .For("Products")
                 .OrderBy("ProductID")
                 .Expand("Category/Products")
-                .Select(new[] {"ProductName", "Category/CategoryName" })
+                .Select(new[] { "ProductName", "Category/CategoryName" })
                 .FindEntriesAsync()).Last();
             Assert.Equal(2, product.Count);
             Assert.Equal(1, (product["Category"] as IDictionary<string, object>).Count);
@@ -543,6 +543,39 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .Filter("Order_Details/all(d:d/Quantity gt 50)")
                 .FindEntriesAsync();
             Assert.Equal(ExpectedCountOfOrdersHavingAllDetails, products.Count());
+        }
+
+        [Fact]
+        public async Task WithHeader()
+        {
+            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+            
+            var request = await client
+                .For("Products")
+                .WithHeader("header1", "header1Value")
+                .WithHeader("header2", "header2Value")
+                .BuildRequestFor()
+                .FindEntryAsync();
+
+            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
+            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
+        }
+
+        [Fact]
+        public async Task WithHeaders()
+        {
+            var client = new ODataClient(CreateDefaultSettings().WithHttpMock());
+
+            var request = await client
+                .For("Products")
+                .WithHeaders(new Dictionary<string, string>{
+                    { "header1", "header1Value" },
+                    { "header2", "header2Value" }})
+                .BuildRequestFor()
+                .FindEntryAsync();
+
+            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
+            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
         }
     }
 }


### PR DESCRIPTION
Added a WithHeaders method to allow setting arbitrary http headers to the produced http request. This is helpfull for example for setting up impersonation in CDS OData calls.