### PR TITLE
Support 'in' operator introduced in OData v4.01

### DIFF
--- a/src/Simple.OData.Client.Core/Expressions/FunctionToOperatorMapping.cs
+++ b/src/Simple.OData.Client.Core/Expressions/FunctionToOperatorMapping.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Simple.OData.Client
+{
+    internal abstract class FunctionToOperatorMapping
+    {
+        public static bool TryGetOperatorMapping(ODataExpression functionCaller, ExpressionFunction function, AdapterVersion adapterVersion,
+            out FunctionToOperatorMapping operatorMapping)
+        {
+            operatorMapping = DefinedMappings.SingleOrDefault(x => x.CanMap(function.FunctionName, function.Arguments.Count, functionCaller, adapterVersion));
+            return operatorMapping != null;
+        }
+
+        public abstract string Format(ExpressionContext context, ODataExpression functionCaller, List<ODataExpression> functionArguments);
+
+        protected abstract bool CanMap(string functionName, int argumentCount, ODataExpression functionCaller, AdapterVersion adapterVersion = AdapterVersion.Any);
+
+        private static readonly FunctionToOperatorMapping[] DefinedMappings =
+        {
+            new InOperatorMapping()
+        };
+    }
+
+    internal class InOperatorMapping : FunctionToOperatorMapping
+    {
+        public override string Format(ExpressionContext context, ODataExpression functionCaller, List<ODataExpression> functionArguments)
+        {
+            var list = functionCaller.Value as IEnumerable;
+            if (list == null)
+            {
+                throw new ArgumentException("Function caller should have a value");
+            }
+            var listAsString = new StringBuilder();
+            var delimiter = string.Empty;
+            listAsString.Append("(");
+            foreach (var item in list)
+            {
+                listAsString.Append(delimiter);
+                listAsString.Append(context.Session.Adapter.GetCommandFormatter().ConvertValueToUriLiteral(item, false));
+                delimiter = ",";
+            }
+            listAsString.Append(")");
+
+            return $"{functionArguments[0].Format(context)} in {listAsString}";
+        }
+
+        protected override bool CanMap(string functionName, int argumentCount, ODataExpression functionCaller, AdapterVersion adapterVersion = AdapterVersion.Any)
+        {
+            return functionName == nameof(Enumerable.Contains) &&
+                   argumentCount == 1 &&
+                   functionCaller.Value != null &&
+                   functionCaller.Value.GetType() != typeof(string) &&
+                   IsInstanceOfType(typeof(IEnumerable), functionCaller.Value) &&
+                   adapterVersion == AdapterVersion.V4;
+        }
+
+        private static bool IsInstanceOfType(Type expectedType, object value)
+        {
+            if (value == null)
+            {
+                return false;
+            }
+            var valueType = value.GetType();
+            if (expectedType.IsAssignableFrom(valueType))
+            {
+                return true;
+            }
+            if (expectedType.IsGenericType && !expectedType.GenericTypeArguments.Any() && valueType.IsGenericType)
+            {
+                var genericArgumentTypes = valueType.GenericTypeArguments;
+                if (!genericArgumentTypes.Any())
+                {
+                    genericArgumentTypes = new[] {typeof(object)};
+                    valueType = valueType.MakeGenericType(genericArgumentTypes);
+                }
+                var expectedGenericType = expectedType.MakeGenericType(genericArgumentTypes);
+                return expectedGenericType.IsAssignableFrom(valueType);
+            }
+            return false;
+        }
+    }
+}

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -94,9 +94,13 @@ namespace Simple.OData.Client
         private string FormatFunction(ExpressionContext context)
         {
             var adapterVersion = context.Session?.Adapter.AdapterVersion ?? AdapterVersion.Default;
-            if (FunctionMapping.TryGetFunctionMapping(this.Function.FunctionName, this.Function.Arguments.Count(), adapterVersion, out var mapping))
+            if (FunctionToOperatorMapping.TryGetOperatorMapping(_functionCaller, Function, adapterVersion, out var operatorMapping))
             {
-                return FormatMappedFunction(context, mapping);
+                return FormatMappedOperator(context, operatorMapping);
+            }
+            if (FunctionMapping.TryGetFunctionMapping(this.Function.FunctionName, this.Function.Arguments.Count(), adapterVersion, out var functionMapping))
+            {
+                return FormatMappedFunction(context, functionMapping);
             }
             else if (string.Equals(this.Function.FunctionName, ODataLiteral.Any, StringComparison.OrdinalIgnoreCase) ||
                      string.Equals(this.Function.FunctionName, ODataLiteral.All, StringComparison.OrdinalIgnoreCase))
@@ -152,7 +156,12 @@ namespace Simple.OData.Client
 
             throw new NotSupportedException($"The function {this.Function.FunctionName} is not supported or called with wrong number of arguments");
         }
-
+        
+        private string FormatMappedOperator(ExpressionContext context, FunctionToOperatorMapping mapping)
+        {
+            return mapping.Format(context, _functionCaller, Function.Arguments);
+        }
+        
         private string FormatMappedFunction(ExpressionContext context, FunctionMapping mapping)
         {
             var mappedFunction = mapping.FunctionMapper(

--- a/src/Simple.OData.Client.UnitTests/Core/FormatSettings.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/FormatSettings.cs
@@ -13,6 +13,7 @@ namespace Simple.OData.Client.Tests.Core
         string GetGuidFormat(string text, bool escapeString = false);
         string GetEnumFormat(object value, Type enumType, string ns, bool prefixFree = false, bool escapeString = false);
         string GetContainsFormat(string item, string text, bool escapeString = false);
+        string GetContainedInFormat(string item, string text, bool escapeString = false);
     }
 
     class ODataV3Format : IFormatSettings
@@ -47,6 +48,14 @@ namespace Simple.OData.Client.Tests.Core
         public string GetContainsFormat(string item, string text, bool escapeString = false)
         {
             var result = $"substringof('{text}',{item})";
+            if (escapeString)
+                result = Uri.EscapeDataString(result);
+            return result;
+        }
+        
+        public string GetContainedInFormat(string item, string text, bool escapeString = false)
+        {
+            var result = $"substringof({item},'{text}')";
             if (escapeString)
                 result = Uri.EscapeDataString(result);
             return result;
@@ -88,6 +97,14 @@ namespace Simple.OData.Client.Tests.Core
         public string GetContainsFormat(string item, string text, bool escapeString = false)
         {
             var result = $"contains({item},'{text}')";
+            if (escapeString)
+                result = Uri.EscapeDataString(result);
+            return result;
+        }
+
+        public string GetContainedInFormat(string item, string text, bool escapeString = false)
+        {
+            var result = $"contains('{text}',{item})";
             if (escapeString)
                 result = Uri.EscapeDataString(result);
             return result;

--- a/src/Simple.OData.Client.UnitTests/Core/TypedFilterAsKeyTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/TypedFilterAsKeyTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+using Microsoft.Data.OData;
 using Xunit;
 
 namespace Simple.OData.Client.Tests.Core
@@ -9,7 +9,17 @@ namespace Simple.OData.Client.Tests.Core
     public class TypedFilterAsKeyV3Tests : TypedFilterAsKeyTests
     {
         public override string MetadataFile => "Northwind3.xml";
-        public override IFormatSettings FormatSettings { get { return new ODataV3Format(); } }
+        public override IFormatSettings FormatSettings => new ODataV3Format();
+
+        [Fact]
+        public async Task FindAllByFilterWithContainsThrowsExceptions()
+        {
+            var list = new List<int> {1};
+            var command = _client
+                .For<Product>()
+                .Filter(x => list.Contains(x.ProductID));
+            await Assert.ThrowsAsync<ODataException>(() => command.GetCommandTextAsync());
+        }
     }
 
     public class TypedFilterAsKeyV4Tests : TypedFilterAsKeyTests
@@ -26,6 +36,17 @@ namespace Simple.OData.Client.Tests.Core
                 .Set(new Dictionary<string, object>() { { "numbers", new[] { 1, 2, 3 } } });
             var commandText = await command.GetCommandTextAsync();
             Assert.Equal("PassThroughIntCollection(numbers=@p1)?@p1=[1,2,3]", commandText);
+        }
+
+        [Fact]
+        public async Task FindAllByFilterWithContains()
+        {
+            var ids = new List<int> {1, 2, 3};
+            var command = _client
+                .For<Product>()
+                .Filter(x => ids.Contains(x.ProductID));
+            var commandText = await command.GetCommandTextAsync();
+            Assert.Equal("Products?$filter=ProductID%20in%20%281%2C2%2C3%29", commandText);
         }
     }
 


### PR DESCRIPTION
Adds support for 'in' operator introduced in OData v4.01 (https://docs.oasis-open.org/odata/new-in-odata/v4.01/cn04/new-in-odata-v4.01-cn04.html#sec_NewinOperator).

Sample:
`var command = _client.For<Product>().Filter(x => ids.Contains(x.ProductID));`

Fixes #684 