### PR TITLE
Fixed missing HttpRequestMessage header assignment from ODataRequest.

### DIFF
--- a/src/Simple.OData.Client.Core/ODataRequest.cs
+++ b/src/Simple.OData.Client.Core/ODataRequest.cs
@@ -134,6 +134,13 @@ namespace Simple.OData.Client
             {
                 Content = this._contentStream != null ? this.GetContent() : null
             };
+
+            if (Headers != null)
+            {
+                foreach (var header in Headers)
+                    _requestMessage.Headers.Add(header.Key, header.Value);
+            }
+
             return _requestMessage;
         }
     }

--- a/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
@@ -557,8 +557,8 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .BuildRequestFor()
                 .FindEntryAsync();
 
-            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
-            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
+            Assert.Equal("header1Value", request.GetRequest().RequestMessage.Headers.GetValues("header1").SingleOrDefault());
+            Assert.Equal("header2Value", request.GetRequest().RequestMessage.Headers.GetValues("header2").SingleOrDefault());
         }
 
         [Fact]
@@ -574,8 +574,8 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .BuildRequestFor()
                 .FindEntryAsync();
 
-            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
-            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
+            Assert.Equal("header1Value", request.GetRequest().RequestMessage.Headers.GetValues("header1").SingleOrDefault()); 
+            Assert.Equal("header2Value", request.GetRequest().RequestMessage.Headers.GetValues("header2").SingleOrDefault());
         }
     }
 }


### PR DESCRIPTION
@object Apologies I missed an obvious bug. I started working an Http headers for batch operations and after digging in a bit deeper I realsed I was testing against the ODataRequest object and the test passed but the headers weren't getting propagated to the actual http request. I fixed the bug and the tests. I will commit the changes for batch http headers on a separate PR.