### PR TITLE
Added ability to set arbitrary http headers on batch requests.

### DIFF
--- a/src/Simple.OData.Client.Core/Adapter/IBatchWriter.cs
+++ b/src/Simple.OData.Client.Core/Adapter/IBatchWriter.cs
@@ -9,7 +9,7 @@ namespace Simple.OData.Client
 {
     public interface IBatchWriter
     {
-        Task<ODataRequest> CreateBatchRequestAsync(IODataClient client, IList<Func<IODataClient, Task>> actions, IList<int> responseIndexes);
+        Task<ODataRequest> CreateBatchRequestAsync(IODataClient client, IList<Func<IODataClient, Task>> actions, IDictionary<string, string> headers = null);
         Task<object> CreateOperationMessageAsync(Uri uri, string method, string collection, IDictionary<string, object> entryData, bool resultRequired);
         bool HasOperations { get; }
         int LastOperationId { get; }

--- a/src/Simple.OData.Client.Core/ODataBatch.cs
+++ b/src/Simple.OData.Client.Core/ODataBatch.cs
@@ -14,8 +14,8 @@ namespace Simple.OData.Client
     {
         private readonly ODataClient _client;
         private readonly List<Func<IODataClient, Task>> _actions = new List<Func<IODataClient, Task>>();
-        private readonly ConcurrentDictionary<object, IDictionary<string, object>> _entryMap = new ConcurrentDictionary<object, IDictionary<string, object>>(); 
-
+        private readonly ConcurrentDictionary<object, IDictionary<string, object>> _entryMap = new ConcurrentDictionary<object, IDictionary<string, object>>();
+        private readonly Dictionary<string, string> headers = new Dictionary<string, string>();
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataBatch"/> class.
         /// </summary>
@@ -50,7 +50,7 @@ namespace Simple.OData.Client
         public ODataBatch(IODataClient client, bool reuseSession)
         {
             _client = reuseSession
-                ? new ODataClient((client as ODataClient), _entryMap) 
+                ? new ODataClient((client as ODataClient), _entryMap)
                 : new ODataClient((client as ODataClient).Session.Settings, _entryMap);
         }
         /// <summary>
@@ -81,7 +81,31 @@ namespace Simple.OData.Client
         /// <returns></returns>
         public Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            return _client.ExecuteBatchAsync(_actions, cancellationToken);
+            return _client.ExecuteBatchAsync(_actions, cancellationToken, headers);
+        }
+
+        public Task<ODataRequest> BuildRequest(CancellationToken cancellationToken)
+        {
+            return _client.BuildRequestForBatch(_actions, cancellationToken, headers);
+        }
+
+        public Task<ODataRequest> BuildRequest()
+        {
+            return BuildRequest(CancellationToken.None);
+        }
+
+        public ODataBatch WithHeader(string name, string value)
+        {
+            headers.Add(name, value);
+            return this;
+        }
+
+        public ODataBatch WithHeaders(IDictionary<string,string> headers)
+        {
+            foreach (var header in headers)
+                WithHeader(header.Key, header.Value);
+
+            return this;
         }
     }
 }

--- a/src/Simple.OData.Client.UnitTests/Core/ExpansionTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/ExpansionTests.cs
@@ -342,6 +342,22 @@ namespace Simple.OData.Client.Tests.Core
         }
 
         [Theory]
+        [InlineData("Northwind3.xml", "Employees?$expand=Superior,Superior/Subordinates,Superior/Superior")]
+        [InlineData("Northwind4.xml", "Employees?$expand=Superior($expand=Subordinates,Superior)")]
+        public async Task ExpandSuperiorWithSubordinatesAndSuperiorInMultipleExpands(string metadataFile, string expectedCommand)
+        {
+            var client = CreateClient(metadataFile);
+            var command = client
+                .For<Employee>()
+                .Expand(x => x.Superior)
+                .Expand(x => x.Superior.Subordinates)
+                .Expand(x => x.Superior.Superior);
+            
+            var commandText = await command.GetCommandTextAsync();
+            Assert.Equal(expectedCommand, commandText);
+        }
+
+        [Theory]
         [InlineData("Northwind3.xml", "Employees?$expand=Superior/Superior/Superior")]
         [InlineData("Northwind4.xml", "Employees?$expand=Superior($expand=Superior($expand=Superior))")]
         public async Task ExpandSuperiorThreeTimes(string metadataFile, string expectedCommand)
@@ -488,7 +504,7 @@ namespace Simple.OData.Client.Tests.Core
 
             var expectedResult =
                 @"ClientProductSkus/FunctionService.GetCreateUpdateSkuDelta(clientId=35,offsetInMinutes=2000)?" +
-                "$expand=Product($expand=ProductCategory($expand=Category($expand=CategorySalesArea;$select=Code);$select=IsPrimary);$expand=SupplierProductSkuClient($expand=SupplierProductSku($expand=SupplierProductSkuPriceList($expand=SupplierPriceList);$expand=SupplierProductSkuOnHand($expand=Warehouse)));$select=Id,ManufacturerId)," +
+                "$expand=Product($expand=ProductCategory($expand=Category($expand=CategorySalesArea;$select=Code);$select=IsPrimary),SupplierProductSkuClient($expand=SupplierProductSku($expand=SupplierProductSkuPriceList($expand=SupplierPriceList),SupplierProductSkuOnHand($expand=Warehouse)));$select=Id,ManufacturerId)," +
                 "ClientProductSkuPriceList($select=CurrencyId)," +
                 "ClientProductSkuSalesArea&" +
                 "$select=PartNo,ClientId,ErpName,EanCode";

--- a/src/Simple.OData.Client.UnitTests/Core/RequestWriterBatchTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/RequestWriterBatchTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Moq;
+
+using Microsoft.Data.OData;
+using Microsoft.Data.Edm;
+
+using Xunit;
+
+namespace Simple.OData.Client.Tests.Core
+{
+    public class RequestWriterBatchV3Tests : RequestWriterBatchTests
+    {
+        public override string MetadataFile => "Northwind3.xml";
+        public override IFormatSettings FormatSettings => new ODataV3Format();
+
+        protected override async Task<IRequestWriter> CreateBatchRequestWriter()
+        {
+            return new V3.Adapter.RequestWriter(
+                _session,
+                await _client.GetMetadataAsync<Microsoft.Data.Edm.IEdmModel>(),
+                new Lazy<IBatchWriter>(() => _session.Adapter.GetBatchWriter(
+                    new Dictionary<object, IDictionary<string, object>>())));
+        }
+    }
+
+    public class RequestWriterBatchV4Tests : RequestWriterBatchTests
+    {
+        public override string MetadataFile => "Northwind4.xml";
+        public override IFormatSettings FormatSettings => new ODataV4Format();
+
+        protected override async Task<IRequestWriter> CreateBatchRequestWriter()
+        {
+            return new V4.Adapter.RequestWriter(
+                _session,
+                await _client.GetMetadataAsync<Microsoft.OData.Edm.IEdmModel>(),
+                new Lazy<IBatchWriter>(() => base.BatchWriter));
+        }
+    }
+
+    public abstract class RequestWriterBatchTests : CoreTestBase
+    {
+        private readonly Dictionary<object, IDictionary<string, object>> _batchContent =
+            new Dictionary<object, IDictionary<string, object>>(3);
+
+        protected Dictionary<object, IDictionary<string, object>> BatchContent => _batchContent;
+
+        protected abstract Task<IRequestWriter> CreateBatchRequestWriter();
+
+        protected IBatchWriter BatchWriter => _session.Adapter.GetBatchWriter(
+                    _batchContent);
+
+        [Fact]
+        public async Task CreateUpdateRequest_NoPreferredVerb_AllProperties_OperationHeaders_Patch()
+        {
+            var requestWriter = await CreateBatchRequestWriter();
+
+            var result = await requestWriter.CreateUpdateRequestAsync("Products", "",
+                        new Dictionary<string, object>() { { "ProductID", 1 } },
+                        new Dictionary<string, object>()
+                        {
+                            { "ProductID", 1 },
+                            { "SupplierID", 2 },
+                            { "CategoryID", 3 },
+                            { "ProductName", "Chai" },
+                            { "EnglishName", "Tea" },
+                            { "QuantityPerUnit", "10" },
+                            { "UnitPrice", 20m },
+                            { "UnitsInStock", 100 },
+                            { "UnitsOnOrder", 1000 },
+                            { "ReorderLevel", 500 },
+                            { "Discontinued", false },
+                        },
+                        false,
+                        new Dictionary<string, string>()
+                        {
+                            { "Header1","HeaderValue1"}
+                        });
+
+            Assert.Equal("PATCH", result.Method);
+            Assert.True(result.Headers.TryGetValue("Header1", out var value) && value == "HeaderValue1");
+            Assert.True(result.RequestMessage.Headers.TryGetValues("Header1", out var values) && values.Contains("HeaderValue1"));
+        }
+    }
+}

--- a/src/Simple.OData.Client.UnitTests/FluentApi/BatchTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/BatchTests.cs
@@ -422,5 +422,20 @@ namespace Simple.OData.Client.Tests.FluentApi
 
             Assert.Equal(ExpectedCountOfProducts, count);
         }
+
+        [Fact]
+        public async Task WithHttpHeaders()
+        {
+            var settings = CreateDefaultSettings().WithHttpMock();
+            var batch = new ODataBatch(settings)
+                .WithHeader("batchHeader", "batchHeaderValue");
+
+            batch += async c => await c.InsertEntryAsync("Products", new Entry() { { "ProductName", "Test21" }, { "UnitPrice", 111m } });
+            batch += async c => await c.InsertEntryAsync("Products", new Entry() { { "ProductName", "Test22" }, { "UnitPrice", 111m } });
+            batch += async c => await c.InsertEntryAsync("Products", new Entry() { { "ProductName", "Test23" }, { "UnitPrice", 111m } });
+
+            var request = await batch.BuildRequest();
+            Assert.True(request.RequestMessage.Headers.TryGetValues("batchHeader", out var values) && values.Single() == "batchHeaderValue");
+        }
     }
 }

--- a/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/FindTests.cs
@@ -557,8 +557,8 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .BuildRequestFor()
                 .FindEntryAsync();
 
-            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
-            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
+            Assert.Equal("header1Value", request.GetRequest().RequestMessage.Headers.GetValues("header1").SingleOrDefault());
+            Assert.Equal("header2Value", request.GetRequest().RequestMessage.Headers.GetValues("header2").SingleOrDefault());
         }
 
         [Fact]
@@ -574,8 +574,8 @@ namespace Simple.OData.Client.Tests.FluentApi
                 .BuildRequestFor()
                 .FindEntryAsync();
 
-            Assert.Equal("header1Value", request.GetRequest().Headers["header1"]);
-            Assert.Equal("header2Value", request.GetRequest().Headers["header2"]);
+            Assert.Equal("header1Value", request.GetRequest().RequestMessage.Headers.GetValues("header1").SingleOrDefault()); 
+            Assert.Equal("header2Value", request.GetRequest().RequestMessage.Headers.GetValues("header2").SingleOrDefault());
         }
     }
 }

--- a/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/CommandFormatter.cs
@@ -130,14 +130,15 @@ namespace Simple.OData.Client.V4.Adapter
                     }
                     else
                     {
-                        clauses.AddRange(association.ExpandAssociations
+                        var expandedProperties = string.Join(",", association.ExpandAssociations
                             .Where(
                                 a => _session.Metadata.HasNavigationProperty(associatedEntityCollection.Name, a.Name))
                             .Select(a =>
                                 FormatExpansionSegment(a, associatedEntityCollection, ODataExpandOptions.ByValue(),
                                     command,
-                                    false))
-                            .Select(formattedExpand => $"{ODataLiteral.Expand}={formattedExpand}"));
+                                    false)));
+                        if (!string.IsNullOrEmpty(expandedProperties))
+                            clauses.Add($"{ODataLiteral.Expand}={expandedProperties}");
                     }
 
                     var selectColumns = string.Join(",", association.ExpandAssociations


### PR DESCRIPTION
Add the abbility to set http headers on batch operations. Changes made to achieve this:

- Added WithHeader/WithHeaders methods to ODataBatch
- Added GetRequest method to ODataBatch to match GetRequestFor functionality on single operations
- ODataRequest now internally carries the batch state (actions and response indeces) needed for replaying actions to set closure values. This is also usefully for exposing the GetRequest.