### PR TITLE
Fix evaluation of constant expression containing mapped properties

### DIFF
--- a/src/ActionProviderImplementation/ActionProviderImplementation.csproj
+++ b/src/ActionProviderImplementation/ActionProviderImplementation.csproj
@@ -4,6 +4,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
@@ -73,8 +73,7 @@ namespace Simple.OData.Client
             }
             else
             {
-                if (memberChain == null)
-                    memberChain = new Stack<MemberInfo>();
+                memberChain ??= new Stack<MemberInfo>();
                 memberChain.Push(memberExpression.Member);
                 switch (memberExpression.Expression.NodeType)
                 {

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
@@ -198,7 +198,7 @@ namespace Simple.OData.Client
                 else
                 {
                     return new ODataExpression(EvaluateConstValue(constExpression.Value,
-                        members == null ? new Stack<MemberInfo>() : members));
+                        members ?? new Stack<MemberInfo>()));
                 }
             }
         }

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
@@ -64,7 +64,7 @@ namespace Simple.OData.Client
             throw Utils.NotSupportedExpression(expression);
         }
 
-        private static ODataExpression ParseMemberExpression(Expression expression, string memberNames = null)
+        private static ODataExpression ParseMemberExpression(Expression expression, Stack<MemberInfo> memberChain = null)
         {
             var memberExpression = expression as MemberExpression;
             if (memberExpression.Expression == null)
@@ -73,24 +73,27 @@ namespace Simple.OData.Client
             }
             else
             {
-                // NOTE: Can't support ITypeCache here as we might be dealing with dynamic types/expressions
-                var memberName = memberExpression.Member.GetMappedName();
-
-                memberNames = memberNames == null ? memberName : string.Join(".", memberName, memberNames);
+                if (memberChain == null)
+                    memberChain = new Stack<MemberInfo>();
+                memberChain.Push(memberExpression.Member);
                 switch (memberExpression.Expression.NodeType)
                 {
                     case ExpressionType.Parameter:
+                        // NOTE: Can't support ITypeCache here as we might be dealing with dynamic types/expressions
+                        var memberNames = string.Join(".", memberChain.Select(x => x.GetMappedName()));
                         return FromReference(memberNames);
                     case ExpressionType.Constant:
-                        return ParseConstantExpression(memberExpression.Expression, memberNames);
+                        return ParseConstantExpression(memberExpression.Expression, memberChain);
                     case ExpressionType.MemberAccess:
+                        // NOTE: Can't support ITypeCache here as we might be dealing with dynamic types/expressions
+                        var memberName = memberExpression.Member.GetMappedName();
                         if (FunctionMapping.ContainsFunction(memberName, 0))
                         {
                             return FromFunction(memberName, ParseMemberExpression(memberExpression.Expression), new List<object>());
                         }
                         else
                         {
-                            return ParseMemberExpression(memberExpression.Expression as MemberExpression, memberNames);
+                            return ParseMemberExpression(memberExpression.Expression as MemberExpression, memberChain);
                         }
 
                     default:
@@ -178,13 +181,13 @@ namespace Simple.OData.Client
             return ParseLinqExpression(lambdaExpression.Body);
         }
 
-        private static ODataExpression ParseConstantExpression(Expression expression, string memberNames = null)
+        private static ODataExpression ParseConstantExpression(Expression expression, Stack<MemberInfo> members = null)
         {
             var constExpression = expression as ConstantExpression;
 
             if (constExpression.Value is Expression)
             {
-                return ParseConstantExpression(constExpression.Value as Expression, memberNames);
+                return ParseConstantExpression(constExpression.Value as Expression, members);
             }
             else
             {
@@ -194,9 +197,8 @@ namespace Simple.OData.Client
                 }
                 else
                 {
-                    return new ODataExpression(EvaluateConstValue(
-                        constExpression.Type, constExpression.Value,
-                        memberNames == null ? new List<string>() : memberNames.Split('.').ToList()));
+                    return new ODataExpression(EvaluateConstValue(constExpression.Value,
+                        members == null ? new Stack<MemberInfo>() : members));
                 }
             }
         }
@@ -327,52 +329,43 @@ namespace Simple.OData.Client
         private static object EvaluateStaticMember(MemberExpression expression)
         {
             object value = null;
-            if (expression.Member is FieldInfo)
+            switch (expression.Member)
             {
-                var fi = (FieldInfo)expression.Member;
-                value = fi.GetValue(null);
-            }
-            else if (expression.Member is PropertyInfo)
-            {
-                var pi = (PropertyInfo)expression.Member;
-                if (pi.GetIndexParameters().Length != 0)
-                    throw new ArgumentException("cannot eliminate closure references to indexed properties.");
-                value = pi.GetValue(null, null);
+                case FieldInfo field:
+                    value = field.GetValue(null);
+                    break;
+                case PropertyInfo property:
+                    if (property.GetIndexParameters().Length != 0)
+                        throw new ArgumentException("cannot eliminate closure references to indexed properties.");
+                    value = property.GetValue(null, null);
+                    break;
             }
             return value;
         }
 
-        private static object EvaluateConstValue(Type type, object value, IList<string> memberNames)
+        private static object EvaluateConstValue(object value, Stack<MemberInfo> memberChain)
         {
-            if (!memberNames.Any())
+            if (!memberChain.Any())
                 return value;
 
-            var memberName = memberNames.First();
-            memberNames = memberNames.Skip(1).ToList();
+            var member = memberChain.Pop();
 
-            Type itemType;
             object itemValue;
-            var property = type.GetNamedProperty(memberName);
-            if (property != null)
+            switch (member)
             {
-                itemType = property.PropertyType;
-                itemValue = property.GetValue(value, null);
-            }
-            else
-            {
-                var field = type.GetAnyField(memberName, true);
-                if (field != null)
-                {
-                    itemType = field.FieldType;
+                case PropertyInfo property:
+                    if (property.GetIndexParameters().Length != 0)
+                        throw new ArgumentException("cannot evaluate constant value of indexed properties.");
+                    itemValue = property.GetValue(value, null);
+                    break;
+                case FieldInfo field:
                     itemValue = field.GetValue(value);
-                }
-                else
-                {
+                    break;
+                default:
                     return value;
-                }
             }
 
-            return EvaluateConstValue(itemType, itemValue, memberNames);
+            return EvaluateConstValue(itemValue, memberChain);
         }
     }
 }

--- a/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
+++ b/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
@@ -6,6 +6,7 @@
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
     <Decription></Decription>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DocumentationFile>Simple.OData.Client.Core.xml</DocumentationFile>

--- a/src/Simple.OData.Client.Dynamic/Simple.OData.Client.Dynamic.csproj
+++ b/src/Simple.OData.Client.Dynamic/Simple.OData.Client.Dynamic.csproj
@@ -4,6 +4,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DocumentationFile>Simple.OData.Client.Dynamic.xml</DocumentationFile>

--- a/src/Simple.OData.Client.UnitTests/Core/TypedExpressionsTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/TypedExpressionsTests.cs
@@ -664,5 +664,23 @@ namespace Simple.OData.Client.Tests.Core
             var filter = filter1 && filter2;
             Assert.Equal("(ProductName eq 'Chai' or ProductID eq 1) and (ProductName eq 'Kaffe' or ProductID eq 2)", filter.AsString(_session));
         }
+
+        [Fact]
+        public void FilterEqualityToMappedPropertyOfOtherEntity()
+        {
+            var otherEntity = new TestEntity
+            {
+                MappedNameUsingDataMemberAttribute = "Other Name"
+            };
+            Expression<Func<TestEntity, bool>> filter = x => x.MappedNameUsingDataMemberAttribute == otherEntity.MappedNameUsingDataMemberAttribute;
+            Assert.Equal("Name eq 'Other Name'", ODataExpression.FromLinqExpression(filter).AsString(_session));
+            
+            otherEntity = new TestEntity
+            {
+                MappedNameUsingJsonPropertyAttribute = "Other Name"
+            };
+            filter = x => x.MappedNameUsingJsonPropertyAttribute == otherEntity.MappedNameUsingJsonPropertyAttribute;
+            Assert.Equal("Name eq 'Other Name'", ODataExpression.FromLinqExpression(filter).AsString(_session));
+        }
     }
 }

--- a/src/Simple.OData.Client.V3.Adapter/Simple.OData.Client.V3.Adapter.csproj
+++ b/src/Simple.OData.Client.V3.Adapter/Simple.OData.Client.V3.Adapter.csproj
@@ -4,6 +4,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup> 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />

--- a/src/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
+++ b/src/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
@@ -4,6 +4,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Core" Version="7.8.3" />

--- a/src/Simple.OData.NorthwindModel/Simple.OData.NorthwindModel.csproj
+++ b/src/Simple.OData.NorthwindModel/Simple.OData.NorthwindModel.csproj
@@ -4,6 +4,7 @@
 	<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/Simple.OData.NorthwindService/Simple.OData.NorthwindService.csproj
+++ b/src/Simple.OData.NorthwindService/Simple.OData.NorthwindService.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Simple.OData.NorthwindService</RootNamespace>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>

--- a/src/Simple.OData.ProductService/Simple.OData.ProductService.csproj
+++ b/src/Simple.OData.ProductService/Simple.OData.ProductService.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Simple.OData.ProductService</RootNamespace>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>

--- a/src/WebApiOData.V3.Samples/WebApiOData.V3.Samples.csproj
+++ b/src/WebApiOData.V3.Samples/WebApiOData.V3.Samples.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>WebApiOData.V3.Samples</RootNamespace>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>

--- a/src/WebApiOData.V4.Samples/WebApiOData.V4.Samples.csproj
+++ b/src/WebApiOData.V4.Samples/WebApiOData.V4.Samples.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>WebApiOData.V4.Samples</RootNamespace>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>


### PR DESCRIPTION
This pull request fix evaluation of constant expressions containing mapped properties. This change should fix #639 