### PR TITLE
Fix for issue #801

### DIFF
--- a/src/Simple.OData.Client.UnitTests/Core/ExpansionTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/ExpansionTests.cs
@@ -440,6 +440,32 @@ namespace Simple.OData.Client.Tests.Core
             Assert.Equal(expectedCommand, commandText);
         }
 
+        [Theory]
+        [InlineData("Northwind3.xml", "Order_Details?$expand=Order&$select=OrderID,Quantity,rde,Order/OrderDate&$orderby=Order/OrderDate,Quantity")]
+        [InlineData("Northwind4.xml", "Order_Details?$expand=Order($select=OrderDate)&$select=OrderID,Quantity,rde&$orderby=Order/OrderDate,Quantity")]
+        public async Task ExpandNavigationPropertyAndPropertyWithContainedName_Issue801(string metadataFile, string expectedCommand)
+        {
+            var client = CreateClient(metadataFile);
+
+            var order_detail = new
+            {
+                OrderID = default(int),
+                Quantity = default(int),
+                Order = default(Order),
+                //A property whose name is contained in the expandable property Order
+                rde = default(int),
+            };
+
+            var command = client.For(order_detail, "Order_Detail")
+                .Expand(x => x.Order)
+                .Select(p => new { p.OrderID, p.Quantity, p.rde, p.Order.OrderDate })
+                .OrderBy(p => p.Order.OrderDate)
+                .ThenBy(p => p.Quantity);
+
+            var commandText = await command.GetCommandTextAsync();
+            Assert.Equal(expectedCommand, commandText);
+        }
+
         [Fact]
         public async Task ExpandSubordinates2LevelsByValue()
         {

--- a/src/Simple.OData.Client.UnitTests/HelperExtensions.cs
+++ b/src/Simple.OData.Client.UnitTests/HelperExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Simple.OData.Client.Tests
+{
+    internal static class HelperExtensions
+    {
+        /// <summary>
+        /// Helper extension to derive the collection type from an instance type. Use to work with anonymous types as entity classes in tests. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="oDataClient"></param>
+        /// <param name="_"></param>
+        /// <param name="collectionName"></param>
+        /// <returns></returns>
+        public static IBoundClient<T> For<T>(this IODataClient oDataClient, T _, string collectionName)
+            where T : class
+           => oDataClient.For<T>(collectionName);
+    }
+}


### PR DESCRIPTION
Fix for issue #801 

The SelectPathSegmentColumns had a lot of unreachable code which I removed. There was a bug in the remaining code where there was a "contains" instead of an "equals" operation so I refactored towards that. This is a regression issue from the August $expand enhancements.

A have added a test against this specific senario, it's not really a functional test so I can remove it after you review it.