### PR TITLE
Optimize RequestExecutor call

### DIFF
--- a/src/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/src/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -35,7 +35,7 @@ namespace Simple.OData.Client
                 HttpResponseMessage response;
                 if (_session.Settings.RequestExecutor != null)
                 {
-                    response = await _session.Settings.RequestExecutor(request.RequestMessage);
+                    response = await _session.Settings.RequestExecutor(request.RequestMessage).ConfigureAwait(false);
                 }
                 else
                 {


### PR DESCRIPTION
This PR slightly optimize the RequestExecutor call by adding `.ConfigureAwait(false)`. This also helps to avoid a deadlock when code is run synchronously using [this approach](https://stackoverflow.com/a/5097066).