### PR TITLE
Fix #818 Move OData v4 dependencies to the correct adapter

### DIFF
--- a/src/Simple.OData.Client.Core/BatchPayloadUriOption.cs
+++ b/src/Simple.OData.Client.Core/BatchPayloadUriOption.cs
@@ -1,0 +1,33 @@
+﻿namespace Simple.OData.Client
+{
+    /// <summary>
+    /// Indicates the format of Request-URI in each sub request in the batch operation.
+    /// </summary>
+    /// <remarks>
+    /// This must be kept aligned with https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Core/Batch/ODataBatchPayloadUriOptions.cs
+    /// </remarks>
+    public enum BatchPayloadUriOption
+    {
+        /// <summary>
+        /// Absolute URI with schema, host, port, and absolute resource path.
+        /// </summary>
+        /// Example:
+        /// GET https://host:1234/path/service/People(1) HTTP/1.1
+        AbsoluteUri,
+
+        /// <summary>
+        /// Absolute resource path and separate Host header.
+        /// </summary>
+        /// Example:
+        /// GET /path/service/People(1) HTTP/1.1
+        /// Host: myserver.mydomain.org:1234
+        AbsoluteUriUsingHostHeader,
+
+        /// <summary>
+        /// Resource path relative to the batch request URI.
+        /// </summary>
+        /// Example:
+        /// GET People(1) HTTP/1.1
+        RelativeUri
+    }
+}

--- a/src/Simple.OData.Client.Core/Cache/TypeCache.cs
+++ b/src/Simple.OData.Client.Core/Cache/TypeCache.cs
@@ -258,10 +258,6 @@ namespace Simple.OData.Client
                 {
                     result = offset.DateTime;
                 }
-                else if ((targetType == typeof(DateTime) || targetType == typeof(DateTime?)) && value is Microsoft.OData.Edm.Date date)
-                {
-                    result = new DateTime(date.Year, date.Month, date.Day);
-                }
                 else if ((targetType == typeof(DateTimeOffset) || targetType == typeof(DateTimeOffset?)) && value is DateTime time)
                 {
                     result = new DateTimeOffset(time);

--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -2,8 +2,6 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.OData;
-using Simple.OData.Client.Extensions;
 
 namespace Simple.OData.Client
 {

--- a/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
+++ b/src/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.OData.Core" Version="7.9.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Simple.OData.Client.Core/ValidationKinds.cs
+++ b/src/Simple.OData.Client.Core/ValidationKinds.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Simple.OData.Client
+{
+    /// <summary>
+    /// Validation kinds used in ODataMessageReaderSettings and ODataMessageWriterSettings.
+    /// </summary>
+    /// <remarks>
+    /// This must be kept aligned with https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Core/ValidationKinds.cs
+    /// </remarks>
+    [Flags]
+    public enum ValidationKinds
+    {
+        /// <summary>
+        /// No validations.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Disallow duplicate properties in ODataResource (i.e., properties with the same name).
+        /// If no duplication can be guaranteed, this flag can be turned off for better performance.
+        /// </summary>
+        ThrowOnDuplicatePropertyNames = 1,
+
+        /// <summary>
+        /// Do not support for undeclared property for non open type.
+        /// </summary>
+        ThrowOnUndeclaredPropertyForNonOpenType = 2,
+
+        /// <summary>
+        /// Validates that the type in input must exactly match the model.
+        /// If the input can be guaranteed to be valid, this flag can be turned off for better performance.
+        /// </summary>
+        ThrowIfTypeConflictsWithMetadata = 4,
+
+        /// <summary>
+        /// Enable all validations.
+        /// </summary>
+        All = ~0
+    }
+}

--- a/src/Simple.OData.Client.V4.Adapter/BatchWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/BatchWriter.cs
@@ -62,7 +62,7 @@ namespace Simple.OData.Client.V4.Adapter
         private async Task<ODataBatchOperationRequestMessage> CreateBatchOperationMessageAsync(
             Uri uri, string method, string collection, string contentId, bool resultRequired)
         {
-            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri, contentId, _session.Settings.BatchPayloadUriOption).ConfigureAwait(false);
+            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri, contentId, (Microsoft.OData.BatchPayloadUriOption) _session.Settings.BatchPayloadUriOption).ConfigureAwait(false);
 
             if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge)
                 message.SetHeader(HttpLiteral.ContentId, contentId);

--- a/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
+++ b/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
@@ -14,7 +14,7 @@ namespace Simple.OData.Client.V4.Adapter
             var readerSettings = new ODataMessageReaderSettings();
             // TODO ODataLib7
             if (settings.IgnoreUnmappedProperties)
-                readerSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+                readerSettings.Validations &= ~Microsoft.OData.ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
             readerSettings.MessageQuotas.MaxReceivedMessageSize = int.MaxValue;
             readerSettings.ShouldIncludeAnnotation = x => settings.IncludeAnnotationsInResults;
 

--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -414,7 +414,7 @@ namespace Simple.OData.Client.V4.Adapter
                     RequestUri = _session.Settings.BaseUri,
                 },
                 EnableMessageStreamDisposal = IsBatch,
-                Validations = _session.Settings.Validations
+                Validations = (Microsoft.OData.ValidationKinds) _session.Settings.Validations
             };
             var contentType = preferredContentType ?? ODataFormat.Json;
             settings.SetContentType(contentType);

--- a/src/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
+++ b/src/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.OData.Core" Version="7.9.0" />
     <ProjectReference Include="..\Simple.OData.Client.Core\Simple.OData.Client.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
More info at #818 . Duplicates the enums defined in Microsoft.Data.OData in order to keep existing clients working as-is, making sure that no code path in the V3 adapter uses V4 data types.