### PR TITLE
Made extension classes in "Simple.OData.Client.Extensions" public

### DIFF
--- a/src/Simple.OData.Client.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/DictionaryExtensions.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Simple.OData.Client.Extensions
 {
-    static class DictionaryExtensions
+    public static class DictionaryExtensions
     {
         private static ConcurrentDictionary<Type, ActivatorDelegate> _defaultActivators = new ConcurrentDictionary<Type, ActivatorDelegate>();
         private static ConcurrentDictionary<Tuple<Type,Type>, ActivatorDelegate> _collectionActivators = new ConcurrentDictionary<Tuple<Type,Type>, ActivatorDelegate>();

--- a/src/Simple.OData.Client.Core/Extensions/EnumerableOfKeyValuePairExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/EnumerableOfKeyValuePairExtensions.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Simple.OData.Client.Extensions
 {
-    static class EnumerableOfKeyValuePairExtensions
+    public static class EnumerableOfKeyValuePairExtensions
     {
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
         {

--- a/src/Simple.OData.Client.Core/Extensions/HomogenizeEx.cs
+++ b/src/Simple.OData.Client.Core/Extensions/HomogenizeEx.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Simple.OData.Client.Extensions
 {
-    static class HomogenizeEx
+    public static class HomogenizeEx
     {
         private static readonly ConcurrentDictionary<string, string> Cache
             = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Simple.OData.Client.Core/Extensions/StringExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/StringExtensions.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Simple.OData.Client.Extensions
 {
-    static class StringExtensions
+    public static class StringExtensions
     {
         public static bool IsAllUpperCase(this string str)
         {

--- a/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace Simple.OData.Client.Extensions
 {
-    static class TypeExtensions
+    public static class TypeExtensions
     {
         public static IEnumerable<Type> DerivedTypes(this Type type)
         {

--- a/src/Simple.OData.Client.Core/Extensions/XElementExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/XElementExtensions.cs
@@ -9,7 +9,7 @@ namespace Simple.OData.Client.Extensions
     /// <summary>
     /// Extension methods for <see cref="XElement"/>.
     /// </summary>
-    static class XElementExtensions
+    public static class XElementExtensions
     {
         public static XElement Element(this XElement element, string prefix, string name)
         {


### PR DESCRIPTION
There are several useful classes containing extension methods in the namespace `Simple.OData.Client.Extensions`. Unfortunately, most - but not all - of them are `internal` and may be useful for certain advanced scenarios. Therefore, I suggest to mark these classes as `public`:
- DictionaryExtensions
- EnumerableOfKeyValuePairExtensions
- HomogenizeEx
- StringExtensions
- TypeExtensions
- XElementExtensions