### PR TITLE
Refactor internal client instantiations

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -200,7 +200,7 @@ namespace Simple.OData.Client
             var entryData = command.CommandData;
 
             IEnumerable<IDictionary<string, object>> result = null;
-            var client = new ODataClient(_settings);
+            var client = new ODataClient(this);
             var entries = await client.FindEntriesAsync(command.Format(), cancellationToken).ConfigureAwait(false);
             if (entries != null)
             {
@@ -223,7 +223,7 @@ namespace Simple.OData.Client
             var collectionName = command.QualifiedEntityCollectionName;
 
             var result = 0;
-            var client = new ODataClient(_settings);
+            var client = new ODataClient(this);
             var entries = await client.FindEntriesAsync(command.Format(), cancellationToken).ConfigureAwait(false);
             if (entries != null)
             {

--- a/src/Simple.OData.Client.Core/ODataClient.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.cs
@@ -58,11 +58,16 @@ namespace Simple.OData.Client
             }
         }
 
-        internal ODataClient(ODataClient client, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
+        internal ODataClient(ODataClient client)
         {
             _settings = client._settings;
             _session = client.Session;
             _requestRunner = client._requestRunner;
+        }
+
+        internal ODataClient(ODataClient client, ConcurrentDictionary<object, IDictionary<string, object>> batchEntries)
+            :this(client)
+        {
             if (batchEntries != null)
             {
                 _batchEntries = batchEntries;


### PR DESCRIPTION
The initial setup of a client from settings is expensive. There are a couple of cases that the code internally creates a client using the original settings. 

One is used to simply create a formatted command in Link/Unlink request. This was refactored to use the resolved command directly.

The other was to execute the entry interation in IterateEntriesAsync. This one was refactored to create a new client using a constructor with the client itself. It practicly copies the settings, session and request runner objects, which in turn are stateless. The only state the client it self holds as far as I can tell is batch related. I guess that's why there is a need for a different client, so that the read iteration is performed outside the batch and the sideffect inside. In any case this patch should be functionally equivilent and cheaper than the previous implementation. 

PS. This was originally part of the v6 changes but it's not breaking and provides a significant performance improvement so I am posting it on v5.