### PR TITLE
V6/compiled expression member accessors

### DIFF
--- a/src/Simple.OData.Client.Core/Cache/TypeCacheExtensions.cs
+++ b/src/Simple.OData.Client.Core/Cache/TypeCacheExtensions.cs
@@ -11,7 +11,7 @@ namespace Simple.OData.Client.Extensions
         {
             var mpn = typeCache.GetMappedPropertiesWithNames(value.GetType());
 
-            return mpn.Select(x => new KeyValuePair<string, object>(x.Item2, x.Item1.GetValue(value, null)))
+            return mpn.Select(x => new KeyValuePair<string, object>(x.Item2, x.Item1.GetValueEx(value)))
                       .ToIDictionary();
         }
 

--- a/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
+++ b/src/Simple.OData.Client.Core/Expressions/ODataExpression.Linq.cs
@@ -336,7 +336,7 @@ namespace Simple.OData.Client
                 case PropertyInfo property:
                     if (property.GetIndexParameters().Length != 0)
                         throw new ArgumentException("cannot eliminate closure references to indexed properties.");
-                    value = property.GetValue(null, null);
+                    value = property.GetValueEx(null);
                     break;
             }
             return value;
@@ -355,10 +355,10 @@ namespace Simple.OData.Client
                 case PropertyInfo property:
                     if (property.GetIndexParameters().Length != 0)
                         throw new ArgumentException("cannot evaluate constant value of indexed properties.");
-                    itemValue = property.GetValue(value, null);
+                    itemValue = property.GetValueEx(value);
                     break;
                 case FieldInfo field:
-                    itemValue = field.GetValue(value);
+                    itemValue = field.GetValueEx(value);
                     break;
                 default:
                     return value;

--- a/src/Simple.OData.Client.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/MemberInfoExtensions.cs
@@ -85,7 +85,7 @@ namespace Simple.OData.Client.Extensions
                     var nameProperty = mappingAttribute.GetType().GetNamedProperty(attributeProperty);
                     if (nameProperty != null)
                     {
-                        var propertyValue = nameProperty.GetValue(mappingAttribute, null);
+                        var propertyValue = nameProperty.GetValueEx(mappingAttribute);
                         if (propertyValue != null)
                             return propertyValue.ToString();
                     }
@@ -93,6 +93,16 @@ namespace Simple.OData.Client.Extensions
             }
 
             return name;
+        }
+
+        public static object GetValueEx(this MemberInfo memberInfo, object instance)
+        {
+            return MemberAccessor.GetValue(instance, memberInfo);
+        }
+
+        public static void SetValueEx(this MemberInfo memberInfo, object instance, object value)
+        {
+            MemberAccessor.SetValue(instance, memberInfo, value);
         }
     }
 

--- a/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
@@ -51,9 +51,9 @@ namespace Simple.OData.Client.Extensions
             return type.GetAllProperties().Where(x => !x.IsNotMapped());
         }
 
-        public static IEnumerable<Tuple<PropertyInfo, string>> GetMappedPropertiesWithNames(this Type type)
+        public static IEnumerable<(PropertyInfo property, string name)> GetMappedPropertiesWithNames(this Type type)
         {
-            return type.GetMappedProperties().Select(p => new Tuple<PropertyInfo, string>(p, p.GetMappedName()));
+            return type.GetMappedProperties().Select(p => (p, p.GetMappedName()));
         }
 
         private static bool IsInstanceProperty(PropertyInfo propertyInfo)
@@ -193,7 +193,7 @@ namespace Simple.OData.Client.Extensions
                 var nameProperty = mappingAttribute.GetType().GetNamedProperty("Name");
                 if (nameProperty != null)
                 {
-                    var propertyValue = nameProperty.GetValue(mappingAttribute, null);
+                    var propertyValue = nameProperty.GetValueEx(mappingAttribute);
                     if (propertyValue != null)
                         return propertyValue.ToString();
                 }

--- a/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
+++ b/src/Simple.OData.Client.Core/Extensions/TypeExtensions.cs
@@ -51,9 +51,9 @@ namespace Simple.OData.Client.Extensions
             return type.GetAllProperties().Where(x => !x.IsNotMapped());
         }
 
-        public static IEnumerable<(PropertyInfo property, string name)> GetMappedPropertiesWithNames(this Type type)
+        public static IEnumerable<Tuple<PropertyInfo, string>> GetMappedPropertiesWithNames(this Type type)
         {
-            return type.GetMappedProperties().Select(p => (p, p.GetMappedName()));
+            return type.GetMappedProperties().Select(p => new Tuple<PropertyInfo, string>(p, p.GetMappedName()));
         }
 
         private static bool IsInstanceProperty(PropertyInfo propertyInfo)

--- a/src/Simple.OData.Client.Core/Reflection/MemberAccessor.cs
+++ b/src/Simple.OData.Client.Core/Reflection/MemberAccessor.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Collections.Concurrent;
+
+namespace Simple.OData.Client
+{
+    internal static class MemberAccessor
+
+    {
+        static readonly ConcurrentDictionary<(Type, Type, MemberInfo), Delegate> getterCache = new ConcurrentDictionary<(Type, Type, MemberInfo), Delegate>();
+        static readonly ConcurrentDictionary<(Type, Type, MemberInfo), Delegate> setterCache = new ConcurrentDictionary<(Type, Type, MemberInfo), Delegate>();
+
+        public static Delegate BuildGetterAccessor(Type type, Type returnType, MemberInfo memberInfo)
+        {
+            var parameter = Expression.Parameter(type);
+
+            var castedParamter =
+                type != memberInfo.DeclaringType ?
+                Expression.Convert(parameter, memberInfo.DeclaringType) : (Expression)parameter;
+
+            var delegateType = Expression.GetDelegateType(new[] { typeof(object), returnType });
+            var body = (Expression)Expression.PropertyOrField(castedParamter, memberInfo.Name);
+
+            if (body.Type != returnType)
+                body = Expression.Convert(body, returnType);
+
+            return Expression.Lambda(delegateType, body, parameter).Compile();
+        }
+
+        public static Delegate BuildSetterAccessor(Type type, Type valueType, MemberInfo memberInfo)
+        {
+            var parameter = Expression.Parameter(type);
+            var valueParameter = Expression.Parameter(valueType);
+
+            var castedParameter =
+                type != memberInfo.DeclaringType ?
+                Expression.Convert(parameter, memberInfo.DeclaringType) : (Expression)parameter;
+
+            var memberType = GetMemberType(memberInfo);
+            var castedValueParameter =
+                valueType != memberType ?
+                Expression.Convert(valueParameter, memberType) : (Expression)valueParameter;
+
+            var delegateType = Expression.GetDelegateType(new[] { typeof(object), valueType, typeof(void) });
+            return Expression.Lambda(delegateType, 
+                Expression.Assign(
+                    Expression.PropertyOrField(castedParameter, memberInfo.Name),
+                    castedValueParameter),
+                    parameter, valueParameter).Compile();
+        }
+
+        private static Type GetMemberType(MemberInfo memberInfo)
+        {
+            if (memberInfo is PropertyInfo propertyInfo)
+                return propertyInfo.PropertyType;
+            else if (memberInfo is FieldInfo fieldInfo)
+                return fieldInfo.FieldType;
+            return null;
+        }
+
+        private static bool CanGet(MemberInfo memberInfo)
+        {
+            if (memberInfo is PropertyInfo propertyInfo)
+                return propertyInfo.CanRead;
+            else if (memberInfo is FieldInfo fieldInfo)
+                return true;
+            else
+                return false;
+        }
+
+        private static bool CanSet(MemberInfo memberInfo)
+        {
+            if (memberInfo is PropertyInfo propertyInfo)
+                return propertyInfo.CanWrite;
+            else if (memberInfo is FieldInfo fieldInfo)
+                return true;
+            else
+                return false;
+        }
+
+        private static MemberInfo GetMemberInfo(Type type, string memberName)
+        {
+            if (TryGetMemberInfo(type, memberName, out var memberInfo))
+                return memberInfo;
+
+            throw new InvalidOperationException($"Property or field {memberName} not found in type {type.FullName}");
+        }
+
+        private static void AssertMemberInfoType(MemberInfo memberInfo)
+        {
+            if (memberInfo.MemberType == MemberTypes.Field || memberInfo.MemberType == MemberTypes.Property)
+                return;
+
+            throw new InvalidOperationException($"Member {memberInfo.Name} is of member type {memberInfo.MemberType}. Only property or field members can be access for value.");
+        }
+
+        private static bool TryGetMemberInfo(Type type, string memberName, out MemberInfo memberInfo)
+        {
+            var propertyInfo = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var fieldInfo = (propertyInfo is null) ?
+                 type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) : null;
+
+            memberInfo = (MemberInfo)propertyInfo ?? fieldInfo;
+
+            return !(memberInfo is null);
+        }
+
+        public static TMember GetValue<TMember>(object instance, MemberInfo memberInfo)
+        {
+            AssertMemberInfoType(memberInfo);
+            if (instance is null) throw new ArgumentNullException(nameof(instance));
+
+            var type = instance.GetType();
+            var key = (type, typeof(TMember), memberInfo);
+            if (!getterCache.TryGetValue(key, out var accessor))
+            {
+                accessor = BuildGetterAccessor(typeof(object), typeof(TMember), memberInfo);
+                getterCache.TryAdd(key, accessor);
+            }
+
+            return ((Func<object, TMember>)accessor)(instance);
+        }
+
+        public static TMember GetValue<TMember>(object instance, string memberName)
+        {
+            if (instance is null) throw new ArgumentNullException(nameof(instance));
+
+            var type = instance.GetType();
+            var memberInfo = GetMemberInfo(type, memberName);
+
+            return GetValue<TMember>(instance, memberInfo);
+        }
+
+        public static object GetValue(object instance, MemberInfo memberInfo)
+            => GetValue<object>(instance, memberInfo);
+
+        public static object GetValue(object instance, string memberName)
+            => GetValue<object>(instance, memberName);
+
+        public static bool TryGetValue<TMember>(object instance, MemberInfo memberInfo, out TMember value)
+        {
+            AssertMemberInfoType(memberInfo);
+
+            value = default;
+
+            if (instance is null) return false;
+
+            var type = instance.GetType();
+            if (!(CanGet(memberInfo)))
+                return false;
+
+            var key = (type, typeof(TMember), memberInfo);
+            if (!getterCache.TryGetValue(key, out var accessor))
+            {
+                accessor = BuildGetterAccessor(typeof(object), typeof(TMember), memberInfo);
+                getterCache.TryAdd(key, accessor);
+            }
+
+            try
+            {
+                value = ((Func<object, TMember>)accessor)(instance);
+            }
+            catch { return false; }
+
+            return true;
+        }
+
+        public static bool TryGetValue<TMember>(object instance, string memberName, out TMember value)
+        {
+            value = default;
+
+            if (instance is null) return false;
+
+            var type = instance.GetType();
+            var memberInfo = GetMemberInfo(type, memberName);
+
+            return TryGetValue<TMember>(instance, memberInfo, out value);
+        }
+
+        public static bool TryGetValue(object instance, MemberInfo memberInfo, out object value)
+            => TryGetValue<object>(instance, memberInfo, out value);
+
+        public static bool TryGetValue(object instance, string memberName, out object value)
+            => TryGetValue<object>(instance, memberName, out value);
+
+        public static void SetValue<TMember>(object instance, MemberInfo memberInfo, TMember value)
+        {
+            AssertMemberInfoType(memberInfo);
+
+            if (instance is null) throw new ArgumentNullException(nameof(instance));
+
+            var type = instance.GetType();
+            var key = (type, typeof(TMember), memberInfo);
+            if (!setterCache.TryGetValue(key, out var accessor))
+            {
+                accessor = BuildSetterAccessor(typeof(object), typeof(TMember), memberInfo);
+                setterCache.TryAdd(key, accessor);
+            }
+
+            ((Action<object, TMember>)accessor)(instance, value);
+        }
+
+        public static void SetValue<TMember>(object instance, string memberName, TMember value)
+        {
+            if (instance is null) throw new ArgumentNullException(nameof(instance));
+
+            var type = instance.GetType();
+            var memberInfo = GetMemberInfo(type, memberName);
+
+            SetValue(instance, memberInfo, value);
+        }
+
+        public static void SetValue(object instance, MemberInfo memberInfo, object value)
+            => SetValue<object>(instance, memberInfo, value);
+
+        public static void SetValue(object instance, string memberName, object value)
+            => SetValue<object>(instance, memberName, value);
+
+        public static bool TrySetValue<TMember>(object instance, MemberInfo memberInfo, TMember value)
+        {
+            AssertMemberInfoType(memberInfo);
+
+            if (instance is null) return false;
+
+            var type = instance.GetType();
+            if (!(CanSet(memberInfo)))
+                return false;
+
+            var key = (type, typeof(TMember), memberInfo);
+            if (!setterCache.TryGetValue(key, out var accessor))
+            {
+                accessor = BuildSetterAccessor(typeof(object), typeof(TMember), memberInfo);
+                setterCache.TryAdd(key, accessor);
+            }
+
+            try
+            {
+                ((Action<object, TMember>)accessor)(instance, value);
+            }
+            catch { return false; }
+
+            return true;
+        }
+
+        public static bool TrySetValue<TMember>(object instance, string memberName, TMember value)
+        {
+            if (instance is null) return false;
+
+            var type = instance.GetType();
+            var memberInfo = GetMemberInfo(type, memberName);
+
+            return TrySetValue(instance, memberInfo, value);
+        }
+
+        public static bool TrySetValue(object instance, MemberInfo memberInfo, object value)
+            => TrySetValue<object>(instance, memberInfo, value);
+
+        public static bool TrySetValue(object instance, string memberName, object value)
+            => TrySetValue<object>(instance, memberName, value);
+    }
+}

--- a/src/Simple.OData.Client.UnitTests/Reflection/MemberAccessorTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Reflection/MemberAccessorTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Simple.OData.Client.Tests.Reflection
+{
+    public class MemberAccessorTests
+    {
+        class TestClass
+        {
+            public string instanceField;
+            public static string staticField = "staticFieldValue";
+            public static string staticFieldToSet = "staticFieldToSetValue";
+
+            public string InstanceProprety { get; set; }
+            public static string StaticProperty { get; } = "staticPropertyValue";
+            public static string StaticPropertyToSet { get; set; } = "staticPropertyToSetValue";
+        }
+
+        [Fact]
+        public void ShouldGetInstancePropertyValue()
+        {
+            var instance = new TestClass
+            {
+                InstanceProprety = "instancePropertyValue"
+            };
+
+            Assert.Equal(instance.InstanceProprety, MemberAccessor.GetValue<string>(instance, nameof(TestClass.InstanceProprety)));
+        }
+
+        [Fact]
+        public void ShouldGetInstanceFieldValue()
+        {
+            var instance = new TestClass
+            {
+                instanceField = "instanceFieldValue"
+            };
+
+            Assert.Equal(instance.instanceField, MemberAccessor.GetValue<string>(instance, nameof(TestClass.instanceField)));
+        }
+
+        [Fact]
+        public void ShouldGetStaticPropertyValue()
+        {
+            Assert.Equal(TestClass.StaticProperty, MemberAccessor.GetValue<string>(null, typeof(TestClass).GetProperty(nameof(TestClass.StaticProperty))));
+        }
+
+        [Fact]
+        public void ShouldGetStaticFieldValue()
+        {
+            Assert.Equal(TestClass.staticField, MemberAccessor.GetValue<string>(null, typeof(TestClass).GetField(nameof(TestClass.staticField))));
+        }
+
+
+
+
+
+
+        [Fact]
+        public void ShouldSetInstancePropertyValue()
+        {
+            var instance = new TestClass
+            {
+                InstanceProprety = "instancePropertyValue"
+            };
+
+            MemberAccessor.SetValue(instance, nameof(TestClass.InstanceProprety), "test");
+
+            Assert.Equal("test", instance.InstanceProprety);
+        }
+
+        [Fact]
+        public void ShouldSetInstanceFieldValue()
+        {
+            var instance = new TestClass
+            {
+                instanceField = "instanceFieldValue"
+            };
+
+            MemberAccessor.SetValue(instance, nameof(TestClass.instanceField), "test");
+
+            Assert.Equal("test", instance.instanceField);
+        }
+
+        [Fact]
+        public void ShouldSetStaticPropertyValue()
+        {
+            MemberAccessor.SetValue(null, typeof(TestClass).GetProperty(nameof(TestClass.StaticPropertyToSet)), "test");
+
+            Assert.Equal("test", TestClass.StaticPropertyToSet);
+        }
+
+        [Fact]
+        public void ShouldSetStaticFieldValue()
+        {
+            MemberAccessor.SetValue(null, typeof(TestClass).GetField(nameof(TestClass.staticFieldToSet)), "test");
+
+            Assert.Equal("test", TestClass.staticFieldToSet);
+        }
+    }
+}
+

--- a/src/Simple.OData.Client.V4.Adapter/Extensions/DynamicDataAggregationBuilder.cs
+++ b/src/Simple.OData.Client.V4.Adapter/Extensions/DynamicDataAggregationBuilder.cs
@@ -50,7 +50,7 @@ namespace Simple.OData.Client.V4.Adapter.Extensions
             var declaredProperties = objectType.GetDeclaredProperties();
             foreach (var property in declaredProperties)
             {
-                var propertyValue = property.GetValue(aggregation);
+                var propertyValue = property.GetValueEx(aggregation);
                 if (propertyValue is ValueTuple<string, ODataExpression> aggregatedProperty) 
                     aggregationClauses.Add(new AggregationClause<object>(property.Name, aggregatedProperty.Item2?.Reference, aggregatedProperty.Item1));
             }
@@ -72,7 +72,7 @@ namespace Simple.OData.Client.V4.Adapter.Extensions
                 var declaredProperties = objectType.GetDeclaredProperties();
                 foreach (var property in declaredProperties)
                 {
-                    var propertyValue = property.GetValue(groupBy);
+                    var propertyValue = property.GetValueEx(groupBy);
                     switch (propertyValue)
                     {
                         case ODataExpression oDataExpression:


### PR DESCRIPTION
Use cached compiled expressions instead of reflection for accessing property getters and setters. This provides a major performance boost especially when deserializing large datasets.

PS This was originally intented for v6 but it's not breaking so I am posting it on v5. 