### PR TITLE
Re-added support for conversion from Microsoft.OData.Edm.Date to DateTime via implicit conversion

### DIFF
--- a/src/Simple.OData.Client.UnitTests/Core/TypeCacheValueConversionTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/TypeCacheValueConversionTests.cs
@@ -6,7 +6,7 @@ namespace Simple.OData.Client.Tests.Core
 {
     public class TypeCacheValueConversionTests
     {
-        private ITypeCache _typeCache => TypeCaches.TypeCache("test", null);
+        private static ITypeCache _typeCache => TypeCaches.TypeCache("test", null);
 
         [Theory]
         [InlineData(1, typeof(int), typeof(byte))]
@@ -39,6 +39,10 @@ namespace Simple.OData.Client.Tests.Core
         [InlineData("2014-02-01T12:00:00.123", typeof(DateTime), typeof(DateTimeOffset?))]
         [InlineData("58D6C94D-B18A-43C9-AC1B-0B5A5BF10C35", typeof(string), typeof(Guid))]
         [InlineData("58D6C94D-B18A-43C9-AC1B-0B5A5BF10C35", typeof(string), typeof(Guid?))]
+        [InlineData("0", typeof(string), typeof(TestEnum))]
+        [InlineData("Something", typeof(string), typeof(TestEnum))]
+        [InlineData("5", typeof(string), typeof(TestEnum?))]
+        [InlineData("Nothing", typeof(string), typeof(TestEnum?))]
         public void TryConvert(object value, Type sourceType, Type targetType)
         {
             var sourceValue = ChangeType(value, sourceType);
@@ -60,6 +64,27 @@ namespace Simple.OData.Client.Tests.Core
             Assert.True(result);
         }
 
+        [Theory]
+        [InlineData("2014-02-01", typeof(Microsoft.OData.Edm.Date), typeof(DateTime))]
+        [InlineData("2014-02-01", typeof(Microsoft.OData.Edm.Date), typeof(DateTime?))]
+        public void TryConvertODataEdmDate(object value, Type sourceType, Type targetType)
+        {
+            var sourceValue = ChangeType(value, sourceType);
+            var result = _typeCache.TryConvert(sourceValue, targetType, out var targetValue);
+            Assert.True(result);
+            Assert.Equal(ChangeType(sourceValue, targetType), ChangeType(targetValue, targetType));
+        }
+
+        [Theory]
+        [InlineData("58D6C94D-B18A-43C9-AC1B-0B5A5BF10C35", typeof(Guid?), typeof(DateTime))]
+        [InlineData("58D6C94D-B18A-43C9-AC1B-0B5A5BF10C35", typeof(Guid), typeof(DateTime?))]
+        public void TryConvertValueWithoutImplicitDateConversionFails(object value, Type sourceType, Type targetType)
+        {
+            var sourceValue = ChangeType(value, sourceType);
+            var result = _typeCache.TryConvert(sourceValue, targetType, out _);
+            Assert.False(result);
+        }
+
         private object ChangeType(object value, Type targetType)
         {
             if (targetType == typeof(string))
@@ -74,8 +99,16 @@ namespace Simple.OData.Client.Tests.Core
                 return new Guid(value.ToString());
             if (Nullable.GetUnderlyingType(targetType) != null)
                 return ChangeType(value, Nullable.GetUnderlyingType(targetType));
+            if (targetType == typeof(Microsoft.OData.Edm.Date))
+                return Microsoft.OData.Edm.Date.Parse(value.ToString());
 
             return Convert.ChangeType(value, targetType);
+        }
+
+        private enum TestEnum
+        {
+            Nothing = 0,
+            Something = 5
         }
     }
 }


### PR DESCRIPTION
Objects that are implicitly convertible to DateTime can now be converted to DateTime and DateTime? by the TypeCache, including Microsoft.OData.Edm.Date, without requiring a Microsoft.OData project reference.

Additional unit tests for Enumeration conversions have also been added.