### PR TITLE
Fixed concurrency issues while initializing metadata cache

### DIFF
--- a/src/Simple.OData.Client.Core/EdmMetadataCache.cs
+++ b/src/Simple.OData.Client.Core/EdmMetadataCache.cs
@@ -40,6 +40,11 @@ namespace Simple.OData.Client
             // Just allow one schema request at a time, unlikely to be much contention but avoids multiple requests for same endpoint.
             await semaphore.WaitAsync().ConfigureAwait(false);
 
+            if (_instances.TryGetValue(key, out found))
+            {
+                return found;
+            }
+
             try
             {
                 // Can't easily lock, could introduce a semaphoreSlim but not sure if it's worth it.

--- a/src/Simple.OData.Client.IntegrationTests/MetadataODataTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/MetadataODataTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -57,6 +55,35 @@ namespace Simple.OData.Client.Tests
                 .Filter("Name eq 'Milk'")
                 .FindEntriesAsync();
             Assert.Equal("Milk", products.Single()["Name"]);
+        }
+
+        [Fact]
+        public async Task ParallelBootstrapping()
+        {
+            ODataClient.ClearMetadataCache();
+            int metadataCallsCount = 0;
+            var settings = new ODataClientSettings
+            {
+                BaseUri = _serviceUri,
+                BeforeRequest = _ => metadataCallsCount++
+            };
+            var client = new ODataClient(settings);
+
+            await Task.WhenAll(
+                // Dispatch 10 calls in parallel
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync(),
+                client.GetMetadataAsStringAsync()
+            );
+
+            Assert.Equal(1, metadataCallsCount);
         }
     }
 }

--- a/src/Simple.OData.Client.IntegrationTests/Simple.OData.Client.IntegrationTests.csproj
+++ b/src/Simple.OData.Client.IntegrationTests/Simple.OData.Client.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
 	<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
The current `master` branch version has a concurrency issue during metadata cache initialization. When starting parallel requests wich a cold/empty cache, a missing double-checked lock leads to multiple, sequential $metadata endpoint calls. 

I implemented a new test to simulate this situation:
`Simple.OData.Client.Tests.MetadataODataTests.ParallelBootstrapping()`

Before fixing the issue:
![image](https://user-images.githubusercontent.com/22449863/135846441-d78afaf8-92ce-46fa-be3e-a4421c51d342.png)

After fixing the issue:
![image](https://user-images.githubusercontent.com/22449863/135847224-e95d4d61-7742-457e-96ce-96168c673ff4.png)
