### PR TITLE
Fix concurrency edge case / race condition

### DIFF
--- a/src/Simple.OData.Client.Core/EdmMetadataCache.cs
+++ b/src/Simple.OData.Client.Core/EdmMetadataCache.cs
@@ -40,14 +40,13 @@ namespace Simple.OData.Client
             // Just allow one schema request at a time, unlikely to be much contention but avoids multiple requests for same endpoint.
             await semaphore.WaitAsync().ConfigureAwait(false);
 
-            if (_instances.TryGetValue(key, out found))
-            {
-                return found;
-            }
-
             try
             {
-                // Can't easily lock, could introduce a semaphoreSlim but not sure if it's worth it.
+                if (_instances.TryGetValue(key, out found))
+                {
+                    return found;
+                }
+
                 found = await valueFactory(key).ConfigureAwait(false);
 
                 return _instances.GetOrAdd(key, found);


### PR DESCRIPTION
Unfortunately, I introduced a race condition with this pull request: #830 

The race condition occurs when 3 or more `ODataClient` instances that do not share their `ISession` instance simultaneously perform a cold-cache call. They all need to fetch metadata at the same time - here's the scenario:
- The first call works fine
- The second call as well, but this one does not release the semaphore
- Therefore, the third call starves while waiting at the "barrier" (`semaphore.WaitAsync()`)

