### PR TITLE
Added pluralisation for 'status'

### DIFF
--- a/src/Simple.OData.Client.Core/SimplePluralizer.cs
+++ b/src/Simple.OData.Client.Core/SimplePluralizer.cs
@@ -117,6 +117,7 @@ internal class SimplePluralizer : IPluralizer
 			"simplex", "simplices", "simplexes",
 			"soliloquy", "soliloquies", "soliloquy",
 			"species", "", "",
+			"status", "statuses", "",
 			"stratum", "strata", "",
 			"swine", "", "",
 			"trout", "", "",

--- a/src/Simple.OData.Client.UnitTests/Core/PluralizerTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/PluralizerTests.cs
@@ -15,6 +15,7 @@ public class PluralizerTests
 	[InlineData("Access", "Accesses")]
 	[InlineData("Life", "Lives")]
 	[InlineData("Codex", "Codices")]
+	[InlineData("Status", "Statuses")]
 	public void PluralizeWord(string word, string expectedResult)
 	{
 		Assert.Equal(expectedResult, _pluralizer.Pluralize(word));
@@ -28,6 +29,7 @@ public class PluralizerTests
 	[InlineData("Accesses", "Access")]
 	[InlineData("Lives", "Life")]
 	[InlineData("Codices", "Codex")]
+	[InlineData("Statuses", "Status")]
 	public void SingularizeWord(string word, string expectedResult)
 	{
 		Assert.Equal(expectedResult, _pluralizer.Singularize(word));


### PR DESCRIPTION
Added a special word rule and associated unit test for "status" to be pluralised to "statuses".

This will fix Open Issue #692