### PR TITLE
Fix creation of group by clause based on nullable properties

### DIFF
--- a/src/Simple.OData.Client.UnitTests/Core/TypedDataAggregationTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/TypedDataAggregationTests.cs
@@ -302,9 +302,41 @@ public class TypedDataAggregationTests : CoreTestBase
 		var commandText = await command.GetCommandTextAsync();
 		Assert.Equal("Products?$apply=filter%28contains%28Category%2FCategoryName%2C%27ab%27%29%29%2Fgroupby%28%28Category%2FCategoryName%29%2Caggregate%28UnitPrice%20with%20average%20as%20AverageUnitPrice%29%29%2Ffilter%28AverageUnitPrice%20gt%20100%29", commandText);
 	}
+
+	[Fact]
+	public async Task GroupByNullablePropertyWithAggregation()
+	{
+		var command = _client
+			.WithExtensions()
+			.For<Product>()
+			.Apply(b => b.GroupBy((x, a) => new ProductGroupedByNullableCategoryIdWithAggregatedProperties
+			{
+				Category = new CategoryWithNullableId
+				{
+					CategoryID = x.Category.CategoryID,
+					CategoryName = x.Category.CategoryName
+				},
+				AverageUnitPrice = a.Average(x.UnitPrice)
+			}));
+
+		var commandText = await command.GetCommandTextAsync();
+		Assert.Equal("Products?$apply=groupby%28%28Category%2FCategoryID%2CCategory%2FCategoryName%29%2Caggregate%28UnitPrice%20with%20average%20as%20AverageUnitPrice%29%29", commandText);
+	}
 }
 
 internal class ProductGroupedByCategoryNameWithAggregatedProperties : Product
 {
 	public decimal AverageUnitPrice { get; set; }
+}
+
+internal class ProductGroupedByNullableCategoryIdWithAggregatedProperties : Product
+{
+	public CategoryWithNullableId Category { get; set; }
+	public decimal AverageUnitPrice { get; set; }
+}
+
+internal class CategoryWithNullableId
+{
+	public int? CategoryID { get; set; }
+	public string CategoryName { get; set; }
 }

--- a/src/Simple.OData.Client.V4.Adapter/Extensions/DataAggregationBuilder.cs
+++ b/src/Simple.OData.Client.V4.Adapter/Extensions/DataAggregationBuilder.cs
@@ -221,6 +221,9 @@ namespace Simple.OData.Client.V4.Adapter.Extensions
 					case MemberInitExpression memberInitExpression:
 						columnNames.AddRange(ExtractColumnNames(memberInitExpression));
 						break;
+					case UnaryExpression unaryExpression when unaryExpression.NodeType == ExpressionType.Convert:
+						columnNames.Add(unaryExpression.Operand.ExtractColumnName(_session.TypeCache));
+						break;
 				}
 			}
 


### PR DESCRIPTION
This PR fixes creation of group by clause within $apply if some properties of destination type are nullable.