### PR TITLE
Annotations are not downloaded if they are not needed

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -344,7 +344,7 @@ public partial class ODataClient
 		{
 			var entityMediaPropertyName = mediaProperties.FirstOrDefault(x => !entry.Data.ContainsKey(x));
 			entityMediaPropertyName ??= FluentCommand.AnnotationsLiteral;
-			if (entry.Annotations != null)
+			if (Session.Settings.IncludeAnnotationsInResults && entry.Annotations != null)
 			{
 				await GetMediaStreamValueAsync(entry.Data, entityMediaPropertyName, entry.Annotations.MediaResource, cancellationToken).ConfigureAwait(false);
 			}


### PR DESCRIPTION
With this fix, unneeded annotations are not downloaded => request time is improved a lot.