### PR TITLE
Add check to IfMatch header

### DIFF
--- a/src/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/src/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -97,7 +97,8 @@ internal class RequestRunner
 			(request.Method == RestVerbs.Put ||
 			 request.Method == RestVerbs.Patch ||
 			 request.Method == RestVerbs.Merge ||
-			 request.Method == RestVerbs.Delete))
+			 request.Method == RestVerbs.Delete)
+			&& (request.RequestMessage.Headers.IfMatch?.Count ?? 0) == 0)
 		{
 			request.RequestMessage.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
 		}


### PR DESCRIPTION
Added check to If-Match header, so EntityTagHeaderValue.Any will only be added when there is no header set.
In the current situation, it will add EntityTagHeaderValue.Any to the header that is already present, causing the If-Match condition to always be true.