### PR TITLE
Add option to use relative uris for requests for associations

### DIFF
--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -267,9 +267,16 @@ public class ODataClientSettings
 	/// <value>
 	/// <c>true</c> to extend reference links to absolute uris; otherwise, <c>false</c>.
 	/// </value>
-	/// <summary>
 	public bool UseAbsoluteReferenceUris { get; set; }
 
+	/// <summary>
+	/// Gets or sets a value indicating whether association uris should be written as absolute uris instead of relative uris.
+	/// </summary>
+	/// <value>
+	/// <c>true</c> to use association using absolute uris; otherwise, <c>false</c>.
+	/// </value>
+	public bool UseAbsoluteAssociationsUri { get; set; } = true;
+	
 	/// <summary>
 	/// Gets or sets the value that indicates either to read untyped properties as strings.
 	/// </summary>

--- a/src/Simple.OData.Client.IntegrationTests/InsertODataTests.cs
+++ b/src/Simple.OData.Client.IntegrationTests/InsertODataTests.cs
@@ -80,20 +80,27 @@ public abstract class InsertODataTests : ODataTestBase
 		Assert.True((int)product["ID"] > 0);
 	}
 
-	[Fact]
-	public async Task InsertProductWithCategory()
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task InsertProductWithCategory(bool useAbsoluteAssociationsUri)
 	{
-		var category = await _client
+		var client = new ODataClient(CreateDefaultSettings(s =>
+		{
+			s.UseAbsoluteAssociationsUri = useAbsoluteAssociationsUri;
+		}));
+		
+		var category = await client
 			.For("Categories")
 			.Set(CreateCategory(1005, "Test5"))
 			.InsertEntryAsync().ConfigureAwait(false);
-		var product = await _client
+		var product = await client
 			.For("Products")
 			.Set(CreateProduct(1007, "Test6", category))
 			.InsertEntryAsync().ConfigureAwait(false);
 
 		Assert.Equal("Test6", product["Name"]);
-		product = await _client
+		product = await client
 			.For("Products")
 			.Filter("Name eq 'Test6'")
 			.Expand(ProductCategoryName)

--- a/src/Simple.OData.Client.UnitTests/FluentApi/InsertTests.cs
+++ b/src/Simple.OData.Client.UnitTests/FluentApi/InsertTests.cs
@@ -133,6 +133,32 @@ public class InsertTests : TestBase
 	}
 
 	[Fact]
+	public async Task InsertProductWithCategoryByRelativeAssociationUri()
+	{
+		var settings = CreateDefaultSettings().WithHttpMock();
+		settings.UseAbsoluteAssociationsUri = false;
+
+		var client = new ODataClient(settings);
+		var category = await client
+			.For("Categories")
+			.Set(new { CategoryName = "Test5" })
+			.InsertEntryAsync().ConfigureAwait(false);
+		var product = await client
+			.For("Products")
+			.Set(new { ProductName = "Test6", UnitPrice = 18m, Category = category })
+			.InsertEntryAsync().ConfigureAwait(false);
+
+		Assert.Equal("Test6", product["ProductName"]);
+		Assert.Equal(category["CategoryID"], product["CategoryID"]);
+		category = await client
+			.For("Categories")
+			.Expand("Products")
+			.Filter("CategoryName eq 'Test5'")
+			.FindEntryAsync().ConfigureAwait(false);
+		Assert.True((category["Products"] as IEnumerable<object>).Count() == 1);
+	}
+	
+	[Fact]
 	public async Task InsertShip()
 	{
 		var client = new ODataClient(CreateDefaultSettings().WithHttpMock());

--- a/src/Simple.OData.Client.V3.Adapter/Metadata.cs
+++ b/src/Simple.OData.Client.V3.Adapter/Metadata.cs
@@ -88,6 +88,9 @@ namespace Simple.OData.Client.V3.Adapter
 
 			if (TryGetEntityType(typeName, out entityType))
 			{
+				if (TryGetEntitySet(entityType, out var entityTypeSet))
+					return entityTypeSet.Name;
+
 				return entityType.Name;
 			}
 
@@ -283,6 +286,16 @@ namespace Simple.OData.Client.V3.Adapter
 				.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
 				.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
 				.BestMatch(x => x.Name, entitySetName, NameMatchResolver);
+
+			return entitySet != null;
+		}
+
+		private bool TryGetEntitySet(IEdmEntityType edmEntityType, out IEdmEntitySet entitySet)
+		{
+			entitySet = _model.SchemaElements
+				.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
+				.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
+				.SingleOrDefault(x => x.ElementType == edmEntityType);
 
 			return entitySet != null;
 		}

--- a/src/Simple.OData.Client.V3.Adapter/Metadata.cs
+++ b/src/Simple.OData.Client.V3.Adapter/Metadata.cs
@@ -292,10 +292,12 @@ namespace Simple.OData.Client.V3.Adapter
 
 		private bool TryGetEntitySet(IEdmEntityType edmEntityType, out IEdmEntitySet entitySet)
 		{
-			entitySet = _model.SchemaElements
+			var matchingSetTypes = _model.SchemaElements
 				.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
 				.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
-				.SingleOrDefault(x => x.ElementType == edmEntityType);
+				.Where(x => x.ElementType == edmEntityType).ToArray();
+
+			entitySet = matchingSetTypes.Length == 1 ? matchingSetTypes[0] : null;
 
 			return entitySet != null;
 		}

--- a/src/Simple.OData.Client.V3.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V3.Adapter/RequestWriter.cs
@@ -193,12 +193,16 @@ public class RequestWriter : RequestWriterBase
 
 	private ODataMessageWriterSettings GetWriterSettings(ODataFormat? preferredContentType = null)
 	{
-		var settings = new ODataMessageWriterSettings()
+		var settings = new ODataMessageWriterSettings
 		{
 			BaseUri = _session.Settings.BaseUri,
 			Indent = true,
 			DisableMessageStreamDisposal = !IsBatch,
 		};
+		
+		if (!_session.Settings.UseAbsoluteAssociationsUri)
+			settings.SetMetadataDocumentUri(_session.Settings.BaseUri);
+
 		var contentType = preferredContentType ?? _session.Settings.PayloadFormat switch
 		{
 			ODataPayloadFormat.Json => _session.Adapter.ProtocolVersion switch
@@ -290,7 +294,7 @@ public class RequestWriter : RequestWriterBase
 
 			var link = new ODataEntityReferenceLink
 			{
-				Url = Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkUri)
+				Url = _session.Settings.UseAbsoluteAssociationsUri ? Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkUri) : new Uri(linkUri, UriKind.Relative)
 			};
 
 			entryWriter.WriteEntityReferenceLink(link);

--- a/src/Simple.OData.Client.V4.Adapter/Metadata.cs
+++ b/src/Simple.OData.Client.V4.Adapter/Metadata.cs
@@ -130,6 +130,9 @@ public class Metadata : MetadataBase
 
 		if (TryGetEntityType(typeName, out entityType))
 		{
+			if (TryGetEntitySet(entityType, out var entityTypeSet))
+				return entityTypeSet.Name;
+
 			return entityType.Name;
 		}
 
@@ -333,6 +336,16 @@ public class Metadata : MetadataBase
 			.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
 			.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
 			.BestMatch(x => x.Name, entitySetName, NameMatchResolver);
+
+		return entitySet != null;
+	}
+
+	private bool TryGetEntitySet(IEdmEntityType edmEntityType, out IEdmEntitySet entitySet)
+	{
+		entitySet = _model.SchemaElements
+			.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
+			.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
+			.SingleOrDefault(x => x.EntityType() == edmEntityType);
 
 		return entitySet != null;
 	}

--- a/src/Simple.OData.Client.V4.Adapter/Metadata.cs
+++ b/src/Simple.OData.Client.V4.Adapter/Metadata.cs
@@ -342,10 +342,12 @@ public class Metadata : MetadataBase
 
 	private bool TryGetEntitySet(IEdmEntityType edmEntityType, out IEdmEntitySet entitySet)
 	{
-		entitySet = _model.SchemaElements
+		var matchingSetTypes = _model.SchemaElements
 			.Where(x => x.SchemaElementKind == EdmSchemaElementKind.EntityContainer)
 			.SelectMany(x => (x as IEdmEntityContainer).EntitySets())
-			.SingleOrDefault(x => x.EntityType() == edmEntityType);
+			.Where(x => x.EntityType() == edmEntityType).ToArray();
+
+		entitySet = matchingSetTypes.Length == 1 ? matchingSetTypes[0] : null;
 
 		return entitySet != null;
 	}

--- a/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/src/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -417,9 +417,8 @@ namespace Simple.OData.Client.V4.Adapter
 					linkUri = linkedCollectionName + (isSingleton ? string.Empty : formattedKey);
 				}
 
-				var link = new ODataEntityReferenceLink
-				{
-					Url = Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkUri)
+				var link = new ODataEntityReferenceLink {
+					Url = _session.Settings.UseAbsoluteAssociationsUri ? Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkUri) : new Uri(linkUri, UriKind.Relative)
 				};
 
 				await entryWriter.WriteEntityReferenceLinkAsync(link).ConfigureAwait(false);
@@ -443,15 +442,19 @@ namespace Simple.OData.Client.V4.Adapter
 		private ODataMessageWriterSettings GetWriterSettings(
 			ODataFormat? preferredContentType = null)
 		{
-			var settings = new ODataMessageWriterSettings()
+			var settings = new ODataMessageWriterSettings
 			{
-				ODataUri = new ODataUri()
+				ODataUri = new ODataUri
 				{
 					RequestUri = _session.Settings.BaseUri,
 				},
 				EnableMessageStreamDisposal = IsBatch,
 				Validations = (Microsoft.OData.ValidationKinds)_session.Settings.Validations
 			};
+
+			if (!_session.Settings.UseAbsoluteAssociationsUri)
+				settings.ODataUri.ServiceRoot = _session.Settings.BaseUri;
+
 			var contentType = preferredContentType ?? ODataFormat.Json;
 			settings.SetContentType(contentType);
 			return settings;


### PR DESCRIPTION
Adds a new option UseAbsoluteAssociationsUri in the settings, when disabled, relative urls are used in the associations (e.g. @odata.bind)

Request will go from:"

>{
	"@odata.type": "#ODataDemo.Product",
	"ID": 1007,
	"Name": "Test6",
	"Description": "Test1",
	"Price": 18.0,
	"Rating": 1,
	"ReleaseDate": "2023-01-13T13:46:45.6218006+01:00",
	"Categories@odata.bind": ["https://services.odata.org/V4/OData/(S(iemb1b0csyws2o44cd4mmntn))/OData.svc/Categories(1005)"]
}

to

>{
	"@odata.context": "https://services.odata.org/V4/OData/(S(j3mvzffkbihcxf4lcocivxhk))/OData.svc/$metadata#ODataDemo.Product",
	"@odata.type": "#ODataDemo.Product",
	"ID": 1007,
	"Name": "Test6",
	"Description": "Test1",
	"Price": 18.0,
	"Rating": 1,
	"ReleaseDate": "2023-01-13T13:46:42.76828+01:00",
	"Categories@odata.bind": ["Categories(1005)"]
}

