### PR TITLE
Added guard to avoid unnecessary session initialization semaphore locks.

### DIFF
--- a/src/Simple.OData.Client.Core/Session.cs
+++ b/src/Simple.OData.Client.Core/Session.cs
@@ -76,6 +76,10 @@ internal class Session : ISession
 	private readonly SemaphoreSlim _initializeSemaphore = new(1);
 	public async Task Initialize(CancellationToken cancellationToken)
 	{
+		//Avoid unnecessary locks
+		if (MetadataCache != null && _adapter != null)
+			return;
+
 		// Just allow one schema request at a time, unlikely to be much contention but avoids multiple requests for same endpoint.
 		await _initializeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Version 5.26 added a semaphore lock on session initialization. However there was no guard against already initialized sessions. On a high contention environment with many parallel odata calls this creating a huge cpu bottleneck. 

A guard is added to avoid unnecessary semaphore locks.