### PR TITLE
Added SemaphoreRequestLimiter to ODataClientSettings

### DIFF
--- a/src/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/src/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -11,14 +11,26 @@ namespace Simple.OData.Client;
 internal class RequestRunner
 {
 	private readonly ISession _session;
+	private SemaphoreSlim? _semaphore;
+	private readonly int _semaphoreLimiter;
 
 	public RequestRunner(ISession session)
 	{
 		_session = session;
+		if (session.Settings.SemaphoreRequestLimiter > 0)
+		{
+			_semaphoreLimiter = session.Settings.SemaphoreRequestLimiter;
+			_semaphore = new SemaphoreSlim(_semaphoreLimiter, _semaphoreLimiter);
+		}
 	}
 
 	public async Task<HttpResponseMessage> ExecuteRequestAsync(ODataRequest request, CancellationToken cancellationToken)
 	{
+		if (_semaphoreLimiter > 0 && _semaphore != null)
+		{
+			await _semaphore.WaitAsync();
+		}
+
 		HttpConnection? httpConnection = null;
 		try
 		{
@@ -79,6 +91,10 @@ internal class RequestRunner
 			if (httpConnection != null && _session.Settings.RenewHttpConnection)
 			{
 				httpConnection.Dispose();
+			}
+			if (_semaphore != null)
+			{
+				_semaphore.Release();
 			}
 		}
 	}

--- a/src/Simple.OData.Client.Core/ODataClientSettings.cs
+++ b/src/Simple.OData.Client.Core/ODataClientSettings.cs
@@ -313,6 +313,14 @@ public class ODataClientSettings
 	public ValidationKinds Validations { get; set; } = ValidationKinds.All;
 
 	/// <summary>
+	/// Gets or sets SemaphoreRequestLimiter.
+	/// </summary>
+	/// <value>
+	/// If set, limits the number of httprequests to input value.
+	/// </value>
+	public int SemaphoreRequestLimiter { get; set; }
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="ODataClientSettings"/> class.
 	/// </summary>
 	public ODataClientSettings()
@@ -408,5 +416,6 @@ public class ODataClientSettings
 		ReadUntypedAsString = session.Settings.ReadUntypedAsString;
 		WebRequestExceptionMessageSource = session.Settings.WebRequestExceptionMessageSource;
 		BatchPayloadUriOption = session.Settings.BatchPayloadUriOption;
+		SemaphoreRequestLimiter = session.Settings.SemaphoreRequestLimiter;
 	}
 }


### PR DESCRIPTION
Added SemaphoreRequestLimiter to ODataClientSettings and corresponding semaphore and semaphoreLimiter to RequestRunner. Enables the setting SemaphoreRequestLimiter which takes an int to set the limit of concurrent requests a client can run. Can prevent error 429.