### PR TITLE
Fix detecting test projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -116,10 +116,6 @@
 		<PackageReference Include="FluentAssertions" Version="6.*" PrivateAssets="All" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.*" PrivateAssets="All" />
 		<PackageReference Include="MSTest" Version="3.*" />
-		
-		<!-- @robertmclaws: Temporary workaround for 8.0 bug: https://github.com/microsoft/vstest/pull/4792 -->
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*-*" />
-		<PackageReference Include="Microsoft.TestPlatform" Version="17.*-*" />
 
 		<!-- @robertmclaws: We will remove these someday -->
 		<PackageReference Include="xunit" Version="2.*" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,9 +2,9 @@
 	<!-- Folder layout -->
 	<PropertyGroup>
 		<IsBenchmarkProject Condition="$(MSBuildProjectName.ToLower().Contains('.benchmarks.'))">true</IsBenchmarkProject>
-		<IsTestProject Condition="$(MSBuildProjectName.ToLower().Contains('.tests.'))">true</IsTestProject>
 		<IsTestAssetProject Condition="$(MSBuildProjectName.ToLower().Contains('tests.shared.'))">true</IsTestAssetProject>
 		<IsSampleProject Condition="$(MSBuildProjectName.ToLower().Contains('.samples.'))">true</IsSampleProject>
+		<IsTestProject Condition=" '$(IsTestAssetProject)' != 'true' AND $(MSBuildProjectName.ToLower().Contains('.tests.'))">true</IsTestProject>
 		<IsNetCore Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' ">true</IsNetCore>
 		<IsPrimaryProject Condition=" '$(IsBenchmarkProject)' != 'true' AND '$(IsTestProject)' != 'true' AND '$(IsTestAssetProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsPrimaryProject>
 

--- a/src/Simple.OData.Tests.Shared.NorthwindService/Simple.OData.Tests.Shared.NorthwindService.csproj
+++ b/src/Simple.OData.Tests.Shared.NorthwindService/Simple.OData.Tests.Shared.NorthwindService.csproj
@@ -5,10 +5,4 @@
 		<DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
-	<!-- @robertmclaws: This is temporary and should be removed when Microsoft.NET.Test.Sdk 17.10 RTMs. -->
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*-*" />
-		<PackageReference Include="Microsoft.TestPlatform" Version="17.*-*" />
-	</ItemGroup>
-	
 </Project>


### PR DESCRIPTION
`IsTestProject` is used by dotnet test VSTest target to detect if a project is or is not a test project. Ensure that we don't mark shared test projects as test projects to avoid running them in a test run because they hold only shared utils, but not any tests.

Fix https://github.com/dotnet/sdk/issues/39814
Fix #929