### PR TITLE
Fix relative next link

### DIFF
--- a/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.1.txt
+++ b/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.1.txt
@@ -1,0 +1,1 @@
+{"Content":null,"ContentHeaders":null,"Method":"GET","RequestHeaders":[{"Key":"Accept","Value":["application\/json","application\/xml","application\/text"]}],"RequestUri":"http:\/\/localhost\/Products?$count=true"}

--- a/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.2.txt
+++ b/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.2.txt
@@ -1,0 +1,18 @@
+{
+	"Content": "{\"@odata.context\": \"$metadata#Products\",\"@odata.metadataEtag\": \"W\/\\\"20240208144657\\\"\",\"value\": [{\"ProductID\": 1,\"ProductName\": \"VersaTray Essentials\",\"Discontinued\": false,\"UnitPrice\": 19.99}, {\"ProductID\": 2,\"ProductName\": \"InkScribe Chronicles\",\"Discontinued\": false,\"UnitPrice\": 12.99}, {\"ProductID\": 3,\"ProductName\": \"Quantum Whispers\",\"Discontinued\": false,\"UnitPrice\": 14.95}, {\"ProductID\": 4,\"ProductName\": \"LuminaSync Earbuds\",\"Discontinued\": false,\"UnitPrice\": 79.99}, {\"ProductID\": 5,\"ProductName\": \"UrbanTrail Hoodie\",\"Discontinued\": false,\"UnitPrice\": 49.95}, {\"ProductID\": 6,\"ProductName\": \"ZenBloom Wall Art\",\"Discontinued\": true,\"UnitPrice\": 39.99}, {\"ProductID\": 7,\"ProductName\": \"GlowDust Highlighter\",\"Discontinued\": false,\"UnitPrice\": 9.99}, {\"ProductID\": 8,\"ProductName\": \"SummitPulse Trekking Poles\",\"Discontinued\": false,\"UnitPrice\": 59.95}, {\"ProductID\": 9,\"ProductName\": \"NebulaNova Building Blocks\",\"Discontinued\": false,\"UnitPrice\": 24.99}, {\"ProductID\": 10,\"ProductName\": \"VelvetLuxe Lip Stains\",\"Discontinued\": false,\"UnitPrice\": 17.5}],\"@odata.nextLink\": \"Products?$skiptoken=10\"}",
+	"ContentHeaders": [{
+			"Key": "Content-Type",
+			"Value": ["application\/json; odata.metadata=minimal"]
+		}, {
+			"Key": "Content-Length",
+			"Value": ["590"]
+		}
+	],
+	"RequestUri": "http:\/\/localhost\/functions\/Products\/Default.MostExpensives()",
+	"ResponseHeaders": [{
+			"Key": "OData-Version",
+			"Value": ["4.0"]
+		}
+	],
+	"StatusCode": 200
+}

--- a/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.3.txt
+++ b/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.3.txt
@@ -1,0 +1,1 @@
+{"Content":null,"ContentHeaders":null,"Method":"GET","RequestHeaders":[{"Key":"Accept","Value":["application\/json","application\/xml","application\/text"]}],"RequestUri":"http:\/\/localhost\/Products?$count=true"}

--- a/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.4.txt
+++ b/MockData/ResponseReaderV4Tests.GetRelativeNextPageLink.4.txt
@@ -1,0 +1,18 @@
+{
+	"Content": "{\"@odata.context\": \"$metadata#Products\",\"@odata.metadataEtag\": \"W\/\\\"20240208144657\\\"\",\"value\": [{\"ProductID\": 11,\"ProductName\": \"PawPal Comfort Bed\",\"Discontinued\": true,\"UnitPrice\": 34.99}, {\"ProductID\": 12,\"ProductName\": \"QuillCraft Vintage Journals\",\"Discontinued\": false}]}",
+	"ContentHeaders": [{
+			"Key": "Content-Type",
+			"Value": ["application\/json; odata.metadata=minimal"]
+		}, {
+			"Key": "Content-Length",
+			"Value": ["590"]
+		}
+	],
+	"RequestUri": "http:\/\/localhost\/functions\/Products\/Default.MostExpensives()",
+	"ResponseHeaders": [{
+			"Key": "OData-Version",
+			"Value": ["4.0"]
+		}
+	],
+	"StatusCode": 200
+}

--- a/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
+++ b/src/Simple.OData.Client.V4.Adapter/ODataExtensions.cs
@@ -18,6 +18,7 @@ internal static class ODataExtensions
 			readerSettings.Validations &= ~Microsoft.OData.ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
 		}
 
+		readerSettings.BaseUri = settings.BaseUri;
 		readerSettings.MessageQuotas.MaxReceivedMessageSize = int.MaxValue;
 		readerSettings.ShouldIncludeAnnotation = x => settings.IncludeAnnotationsInResults;
 

--- a/src/Simple.OData.Tests.Client/Core/ResponseReaderV4Tests.cs
+++ b/src/Simple.OData.Tests.Client/Core/ResponseReaderV4Tests.cs
@@ -1,8 +1,9 @@
-﻿using System.Text;
+using System.Text;
 using FluentAssertions;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Moq;
+using Simple.OData.Client;
 using Simple.OData.Client.V4.Adapter;
 using Xunit;
 
@@ -50,5 +51,33 @@ public class ResponseReaderV4Tests : CoreTestBase
 		mock.Setup(x => x.GetStream()).Returns(new MemoryStream(Encoding.UTF8.GetBytes(document)));
 		mock.Setup(x => x.GetHeader("Content-Type")).Returns(() => "application/json; type=feed; charset=utf-8");
 		return mock.Object;
+	}
+
+	[Fact]
+	public async Task GetRelativeNextPageLink()
+	{
+		var settings = new ODataClientSettings {
+			BaseUri = new Uri("http://localhost"),
+			MetadataDocument = GetResourceAsString("Northwind4.xml"),
+			PayloadFormat = ODataPayloadFormat.Json
+		};
+		settings = settings.WithHttpMock();
+		var client = new ODataClient(settings);
+
+		var annotations = new ODataFeedAnnotations();
+
+		var response = await client
+			.For("Products")
+			.FindEntriesAsync(annotations);
+
+		Assert.Equal(10, response.Count());
+		Assert.NotNull(annotations.NextPageLink);
+
+		var response2 = await client
+			.For("Products")
+			.FindEntriesAsync(annotations);
+
+		Assert.Equal(2, response2.Count());
+		Assert.Null(annotations.NextPageLink);
 	}
 }


### PR DESCRIPTION
The error occurs in `Microsoft.OData.JsonLight.ODataJsonLightContextUriParser` because it is unable to form an absolute uri using the `@odata.context` itself, or in combination with the BaseUri from its reader settings. Reusing the BaseUri from the ODataClientSettings for the ODataMessageReaderSettings resolves the issue.

The tests with this fix worked fine on the 6.0.1 version - but I'm having some trouble running the tests on the current master branch, even without any changes.

Fixes this issue:
#932 