### PR TITLE
A few perf tweaks

### DIFF
--- a/src/Simple.OData.Client.Core/Extensions/HomogenizeEx.cs
+++ b/src/Simple.OData.Client.Core/Extensions/HomogenizeEx.cs
@@ -3,11 +3,20 @@ using System.Text.RegularExpressions;
 
 namespace Simple.OData.Client.Extensions;
 
-internal static class HomogenizeEx
+internal static partial class HomogenizeEx
 {
 	private static readonly ConcurrentDictionary<string, string> Cache
 		= new(StringComparer.OrdinalIgnoreCase);
-	private static Regex _homogenizeRegex = new(@"[\s\p{P}]");
+
+	private static Regex _homogenizeRegex =
+#if !NET
+		new(@"[\s\p{P}]", RegexOptions.Compiled);
+#else
+		GetDefaultHomogenizeRegex();
+
+	[GeneratedRegex(@"[\s\p{P}]")]
+	private static partial Regex GetDefaultHomogenizeRegex();
+#endif
 
 	/// <summary>
 	/// Downshift a string and remove all non-alphanumeric characters.

--- a/src/Simple.OData.Client.Core/NameMatchResolvers.cs
+++ b/src/Simple.OData.Client.Core/NameMatchResolvers.cs
@@ -8,6 +8,12 @@ public static class ODataNameMatchResolver
 	public static INameMatchResolver Alpahumeric = new ExactMatchResolver(true);
 	public static INameMatchResolver AlpahumericCaseInsensitive = new ExactMatchResolver(true, StringComparison.InvariantCultureIgnoreCase);
 	public static INameMatchResolver NotStrict = new BestMatchResolver();
+
+	internal static string LastPostDotSegment(string input)
+	{
+		int lastDot = input.LastIndexOf('.');
+		return lastDot >= 0 ? input.Substring(lastDot + 1) : input;
+	}
 }
 
 public static class Pluralizers
@@ -23,8 +29,8 @@ public class ExactMatchResolver(bool alphanumComparison = false, StringCompariso
 
 	public bool IsMatch(string actualName, string requestedName)
 	{
-		actualName = actualName.Split('.').Last();
-		requestedName = requestedName.Split('.').Last();
+		actualName = ODataNameMatchResolver.LastPostDotSegment(actualName);
+		requestedName = ODataNameMatchResolver.LastPostDotSegment(requestedName);
 		if (_alphanumComparison)
 		{
 			actualName = actualName.Homogenize();
@@ -46,8 +52,8 @@ public class BestMatchResolver : INameMatchResolver
 
 	public bool IsMatch(string actualName, string requestedName)
 	{
-		actualName = actualName.Split('.').Last().Homogenize();
-		requestedName = requestedName.Split('.').Last().Homogenize();
+		actualName = ODataNameMatchResolver.LastPostDotSegment(actualName).Homogenize();
+		requestedName = ODataNameMatchResolver.LastPostDotSegment(requestedName).Homogenize();
 
 		return actualName == requestedName ||
 			   (actualName == _pluralizer.Singularize(requestedName) ||

--- a/src/Simple.OData.Client.Core/SimplePluralizer.cs
+++ b/src/Simple.OData.Client.Core/SimplePluralizer.cs
@@ -1,4 +1,6 @@
-﻿namespace Simple.OData.Client;
+﻿using System.Text;
+
+namespace Simple.OData.Client;
 
 // Based on gist by Juliën Hanssens
 // https://gist.github.com/hanssens/2835960
@@ -242,7 +244,11 @@ internal class SimplePluralizer : IPluralizer
 
 	private static string? ToPluralInternal(string s)
 	{
-		if (string.IsNullOrEmpty(s) || s.ToCharArray().Any(x => x > 0x7F))
+#if NET8_0_OR_GREATER
+		if (string.IsNullOrEmpty(s) || !Ascii.IsValid(s))
+#else
+		if (string.IsNullOrEmpty(s) || s.Any(x => x > 0x7F))
+#endif
 		{
 			return s;
 		}
@@ -265,7 +271,11 @@ internal class SimplePluralizer : IPluralizer
 
 	private static string? ToSingularInternal(string s)
 	{
-		if (string.IsNullOrEmpty(s) || s.ToCharArray().Any(x => x > 0x7F))
+#if NET8_0_OR_GREATER
+		if (string.IsNullOrEmpty(s) || !Ascii.IsValid(s))
+#else
+		if (string.IsNullOrEmpty(s) || s.Any(x => x > 0x7F))
+#endif
 		{
 			return s;
 		}


### PR DESCRIPTION
Happened to notice a few things as I was looking at a trace of an app using this library...
- SimplePluralizer was using ToCharArray and then Any in both ToPluralInternal and ToSingularInternal. The ToCharArray is an expensive nop and can simply be removed. On .NET 8, Ascii.IsValid can be used instead of the Any call without loss of readability and is much faster.
- ODataNameMatchResolver is using Split().Last. It can just use LastIndexOf and Substring to avoid the string[] and strings for any other segments other than the last.
- HomogenizeEx can use a compiled / source generated regex.

Before

| Method    | Mean     | Allocated |
|---------- |---------:|----------:|
| Pluralize | 268.6 ns |      80 B |
| Resolve   | 213.1 ns |     320 B |

After

| Method    | Mean     | Allocated |
|---------- |---------:|----------:|
| Pluralize | 236.4 ns |      40 B |
| Resolve   | 124.1 ns |     256 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using Simple.OData.Client;

BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class Tests
{
    [Benchmark]
    public string Pluralize() => Pluralizers.Simple.Pluralize("runner");

    [Benchmark]
    public bool Resolve() => ODataNameMatchResolver.NotStrict.IsMatch("actualName", "requestedName");
}
```
