### PR TITLE
Added prediction of Semaphore locking.

### DIFF
--- a/src/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/src/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -19,6 +19,11 @@ internal class RequestRunner
 		}
 	}
 
+	public bool WillLock()
+	{
+		return (_semaphore != null ? (_semaphore.CurrentCount > 0 ? false : true) : false);
+	}
+
 	public async Task<HttpResponseMessage> ExecuteRequestAsync(ODataRequest request, CancellationToken cancellationToken)
 	{
 		if (_maxConcurrentRequests > 0 && _semaphore is not null)

--- a/src/Simple.OData.Client.Core/IODataClient.cs
+++ b/src/Simple.OData.Client.Core/IODataClient.cs
@@ -606,4 +606,9 @@ public interface IODataClient
 	Task<T[]> ExecuteActionAsArrayAsync<T>(string actionName, IDictionary<string, object> parameters, CancellationToken cancellationToken);
 	Task<ODataResponse> GetResponseAsync(ODataRequest request);
 	Task<ODataResponse> GetResponseAsync(ODataRequest request, CancellationToken cancellationToken);
+	/// <summary>
+	/// Tests wether there is any available threads (semaphores) to process.
+	/// </summary>
+	/// <returns>true if any call will cause a lock by the call</returns>
+	bool NextCallWillLock();
 }

--- a/src/Simple.OData.Client.Core/ODataClient.cs
+++ b/src/Simple.OData.Client.Core/ODataClient.cs
@@ -197,4 +197,11 @@ public partial class ODataClient : IODataClient
 			}
 		};
 	}
+
+	/// <summary>
+	/// Tests wether there is any available threads (semaphores) to process.
+	/// </summary>
+	/// <returns>true if any call will cause a lock by the call</returns>
+	bool IODataClient.NextCallWillLock() => _requestRunner.WillLock();
+
 }


### PR DESCRIPTION
When using the semaphore counter to Dynamics 365 CE, we sometimes found that it would be helpful to predict if the next call would lock. 
If so - we use another connection to Dynamics 365 CE.
